### PR TITLE
DB.Wrap(*sql.DB) - Add support for using custom sql.DB instance

### DIFF
--- a/godb.go
+++ b/godb.go
@@ -81,9 +81,9 @@ func (db *DB) Clone() *DB {
 // Wrap creates a godb.DB by using provided and initialized sql.DB Helpful for
 // using custom configured sql.DB instance for godb. Can be used before
 // starting a goroutine.
-func (db *DB) Wrap(dbInst *sql.DB) *DB {
+func (db *DB) Wrap(adapter adapters.Adapter, dbInst *sql.DB) *DB {
 	clone := &DB{
-		adapter:      db.adapter,
+		adapter:      adapter,
 		sqlDB:        dbInst,
 		sqlTx:        nil,
 		logger:       db.logger,

--- a/godb.go
+++ b/godb.go
@@ -29,7 +29,7 @@ type DB struct {
 const Placeholder string = "?"
 
 // ErrOpLock is an error returned when Optimistic Locking failure occurs
-var ErrOpLock = errors.New("Optimistic Locking Failure")
+var ErrOpLock = errors.New("optimistic locking failure")
 
 // Open creates a new DB struct and initialise a sql.DB connection.
 func Open(adapter adapters.Adapter, dataSourceName string) (*DB, error) {
@@ -51,7 +51,7 @@ func Open(adapter adapters.Adapter, dataSourceName string) (*DB, error) {
 }
 
 // Clone creates a copy of an existing DB, without the current transaction.
-// The clone has no consumed time, and new prepared statements caches with
+// The clone has consumedTime set to zero, and new prepared statements caches with
 // the same characteristics.
 // Use it to create new DB object before starting a goroutine.
 func (db *DB) Clone() *DB {
@@ -78,8 +78,35 @@ func (db *DB) Clone() *DB {
 	return clone
 }
 
+// Wrap creates a godb.DB by using provided and initialized sql.DB Helpful for
+// using custom configured sql.DB instance for godb. Can be used before
+// starting a goroutine.
+func (db *DB) Wrap(dbInst *sql.DB) *DB {
+	clone := &DB{
+		adapter:      db.adapter,
+		sqlDB:        dbInst,
+		sqlTx:        nil,
+		logger:       db.logger,
+		consumedTime: 0,
+		stmtCacheDB:  newStmtCache(),
+		stmtCacheTx:  newStmtCache(),
+	}
+
+	clone.stmtCacheDB.SetSize(db.stmtCacheDB.GetSize())
+	if !db.stmtCacheDB.IsEnabled() {
+		clone.stmtCacheDB.Disable()
+	}
+
+	clone.stmtCacheTx.SetSize(db.stmtCacheTx.GetSize())
+	if !db.stmtCacheTx.IsEnabled() {
+		clone.stmtCacheTx.Disable()
+	}
+
+	return clone
+}
+
 // Close closes an existing DB created by Open.
-// Dont't close a cloned DB still used by others goroutines as the sql.DB
+// Don't close a cloned DB still used by others goroutines as the sql.DB
 // is shared !
 // Don't use a DB anymore after a call to Close.
 func (db *DB) Close() error {
@@ -132,7 +159,7 @@ func (db *DB) quoteAll(identifiers []string) []string {
 	return quotedIdentifiers
 }
 
-// replacePlaceholders uses the adapter to change placehodlers according to
+// replacePlaceholders uses the adapter to change placeholders according to
 // the database used.
 func (db *DB) replacePlaceholders(sql string) string {
 	placeholderReplacer, ok := (db.adapter).(adapters.PlaceholdersReplacer)


### PR DESCRIPTION
`DB.Wrap(*sql.DB)` - Add support for using custom `*sql.DB` instance and also corrected some spellings.