### PR TITLE
Added Scan(dest...) method

### DIFF
--- a/select_statement.go
+++ b/select_statement.go
@@ -297,6 +297,32 @@ func (ss *SelectStatement) do(recordInfo *recordDescription, pointersGetter poin
 	return err
 }
 
+// Scan runs the request and scans results to dest params
+func (ss *SelectStatement) Scan(dest ...interface{}) error {
+	stmt, args, err := ss.ToSQL()
+	if err != nil {
+		return err
+	}
+	stmt = ss.db.replacePlaceholders(stmt)
+	ss.db.logPrintln("SELECT : ", stmt, args)
+
+	startTime := time.Now()
+	queryable, err := ss.db.getQueryable(stmt)
+	if err != nil {
+		return err
+	}
+	err = queryable.QueryRow(args...).Scan(dest...)
+	consumedTime := timeElapsedSince(startTime)
+	ss.db.addConsumedTime(consumedTime)
+	ss.db.logDuration(consumedTime)
+	if err != nil {
+		ss.db.logPrintln("ERROR : ", err)
+		return err
+	}
+
+	return nil
+}
+
 // Count runs the request with COUNT(*) (remove others columns)
 // and returns the count.
 func (ss *SelectStatement) Count() (int64, error) {

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -457,6 +457,25 @@ func TestCount(t *testing.T) {
 	})
 }
 
+func TestScan(t *testing.T) {
+	Convey("Given a test database", t, func() {
+		db := fixturesSetup(t)
+		defer db.Close()
+
+		Convey("Scan runs and fills destination columns", func() {
+			selectStmt := db.SelectFrom("dummies")
+			num := 0
+			err := selectStmt.Where("an_integer = ?", 12).Columns("an_integer").Scan(&num)
+			So(err, ShouldBeNil)
+			So(num, ShouldEqual, 12)
+
+			Convey("Do compute time consumed by SQL query", func() {
+				So(db.ConsumedTime(), ShouldBeGreaterThan, 0)
+			})
+		})
+	})
+}
+
 func TestSelectDoWithIterator(t *testing.T) {
 	Convey("Given a test database", t, func() {
 		db := fixturesSetup(t)


### PR DESCRIPTION
Without declaring a struct, selected columns can be fetched into destination variables. For example:
```go
 err := db.Where("an_integer = ?", 12).Columns("an_integer").Scan(&num)
```