### PR TITLE
Added logger interface and more prefixed logging for SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ godb is a project that is still young and evolving. The API is almost stable, bu
 * Two adjustable prepared statements caches (with/without transaction).
 * `RETURNING` support for PostgreSQL.
 * `OUTPUT` support for SQL Server.
+* Define your own logger (should have `Println(...)` method)
 * Could by used with
   * SQLite
   * PostgreSQL

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ func main() {
 	// Connect to the DB
 	db, err := godb.Open(sqlite.Adapter, "./library.db")
 	panicIfErr(err)
+	// OPTIONAL: Set logger to show SQL execution logs
+	db.SetLogger(log.New(os.Stderr, "", 0))
 
 	// Single insert (id will be updated)
 	err = db.Insert(&bookTheHobbit).Do()

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ import (
 
 	"github.com/samonzeweb/godb"
 	"github.com/samonzeweb/godb/adapters/sqlite"
+	"log"
+	"os"
 )
 
 /*

--- a/godb.go
+++ b/godb.go
@@ -3,7 +3,6 @@ package godb
 import (
 	"database/sql"
 	"errors"
-	"log"
 	"strings"
 	"time"
 
@@ -16,8 +15,8 @@ import (
 type DB struct {
 	adapter      adapters.Adapter
 	sqlDB        *sql.DB
-	sqlTx        *sql.Tx
-	logger       *log.Logger
+	sqlTx        *sql.Tx	
+	logger       Logger
 	consumedTime time.Duration
 
 	// Prepared Statement cache for DB and Tx

--- a/logger.go
+++ b/logger.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 )
 
-var logPrefix = "SQL:"
-var prefixedLog []interface{}
+const logPrefix = "SQL:"
 
+// Logger is interface for custom logger
+// Should implement `Println(v ...interface{})` method
 type Logger interface {
 	Println(v ...interface{})
 }
@@ -16,27 +17,26 @@ type Logger interface {
 // By default there is no logger.
 func (db *DB) SetLogger(logger Logger) {
 	db.logger = logger
-	prefixedLog = append(prefixedLog, logPrefix)
 }
 
 // logPrintln is a wrapper for log.Logger.Println with the DB.logger
 // as Logger.
 func (db *DB) logPrintln(v ...interface{}) {
 	if db.logger != nil {
-		db.logger.Println(append(prefixedLog,v)...)
+		db.logger.Println(logPrefix, v)
 	}
 }
 
 // logExecution adds a log with a duration and SQL statement.
 func (db *DB) logExecution(duration time.Duration, v ...interface{}) {
 	if db.logger != nil {
-		db.logger.Println(append(prefixedLog, v, fmt.Sprintf("(Duration: %v)", duration))...)
+		db.logger.Println(logPrefix, v, fmt.Sprintf("(Duration: %v)", duration))
 	}
 }
 
 // logExecution adds a log with a duration and SQL statement.
 func (db *DB) logExecutionErr(err error, v ...interface{}) {
 	if db.logger != nil {
-		db.logger.Println(append(prefixedLog, v, fmt.Sprintf("(ERROR: %v)", err))...)
+		db.logger.Println(logPrefix, v, fmt.Sprintf("(ERROR: %v)", err))
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,13 +1,16 @@
 package godb
 
 import (
-	"log"
 	"time"
 )
 
+type Logger interface {
+	Println(v ...interface{})
+}
+
 // SetLogger sets the logger for the given DB.
 // By default there is no logger.
-func (db *DB) SetLogger(logger *log.Logger) {
+func (db *DB) SetLogger(logger Logger) {
 	db.logger = logger
 }
 

--- a/logger.go
+++ b/logger.go
@@ -2,7 +2,11 @@ package godb
 
 import (
 	"time"
+	"fmt"
 )
+
+var logPrefix = "SQL:"
+var prefixedLog []interface{}
 
 type Logger interface {
 	Println(v ...interface{})
@@ -12,19 +16,27 @@ type Logger interface {
 // By default there is no logger.
 func (db *DB) SetLogger(logger Logger) {
 	db.logger = logger
+	prefixedLog = append(prefixedLog, logPrefix)
 }
 
 // logPrintln is a wrapper for log.Logger.Println with the DB.logger
 // as Logger.
 func (db *DB) logPrintln(v ...interface{}) {
 	if db.logger != nil {
-		db.logger.Println(v...)
+		db.logger.Println(append(prefixedLog,v)...)
 	}
 }
 
-// logDuration adds a log with a duration.
-func (db *DB) logDuration(duration time.Duration) {
+// logExecution adds a log with a duration and SQL statement.
+func (db *DB) logExecution(duration time.Duration, v ...interface{}) {
 	if db.logger != nil {
-		db.logPrintln("Duration : ", duration)
+		db.logger.Println(append(prefixedLog, v, fmt.Sprintf("(Duration: %v)", duration))...)
+	}
+}
+
+// logExecution adds a log with a duration and SQL statement.
+func (db *DB) logExecutionErr(err error, v ...interface{}) {
+	if db.logger != nil {
+		db.logger.Println(append(prefixedLog, v, fmt.Sprintf("(ERROR: %v)", err))...)
 	}
 }

--- a/select_statement.go
+++ b/select_statement.go
@@ -304,19 +304,19 @@ func (ss *SelectStatement) Scanx(dest ...interface{}) error {
 		return err
 	}
 	stmt = ss.db.replacePlaceholders(stmt)
-	ss.db.logPrintln("SELECT : ", stmt, args)
 
 	startTime := time.Now()
 	queryable, err := ss.db.getQueryable(stmt)
 	if err != nil {
+		ss.db.logExecutionErr(err, stmt, args)
 		return err
 	}
 	err = queryable.QueryRow(args...).Scan(dest...)
 	consumedTime := timeElapsedSince(startTime)
 	ss.db.addConsumedTime(consumedTime)
-	ss.db.logDuration(consumedTime)
+	ss.db.logExecution(consumedTime, stmt, args)
 	if err != nil {
-		ss.db.logPrintln("ERROR : ", err)
+		ss.db.logExecutionErr(err, stmt, args)
 		return err
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -50,7 +50,7 @@ func (db *DB) Commit() error {
 	db.logExecution(consumedTime, "COMMIT")
 	db.sqlTx = nil
 	if err!=nil {
-		db.logExecution(consumedTime, "COMMIT")
+		db.logExecutionErr(err, "COMMIT")
 	}
 	return err
 }
@@ -68,7 +68,7 @@ func (db *DB) Rollback() error {
 	db.addConsumedTime(consumedTime)
 	db.logExecution(consumedTime, "ROLLBACK")
 	if err!=nil {
-		db.logExecution(consumedTime, "ROLLBACK")
+		db.logExecutionErr(err, "ROLLBACK")
 	}
 	db.sqlTx = nil
 	return err


### PR DESCRIPTION
- Logger is now an interface. You can use your own logger.
- And SQL logging is polished and concentrated:
   - SQL and durations will be logged like: 
```
SQL: [select * from books where author in (select author from books where title = ?) [The Hobbit]] (Duration: 48.067µs)
```
   - And errors:
```
SQL: [SELECT id, title, authorx, published FROM books []] (ERROR: no such column: authorx)
```