### PR TITLE
added JSONStr and CompactJSONStr

### DIFF
--- a/dbreflect/scannable.go
+++ b/dbreflect/scannable.go
@@ -23,6 +23,10 @@ func init() {
 	// Custom nullable types
 	RegisterScannableStruct(types.NullTime{})
 	RegisterScannableStruct(types.NullBytes{})
+	RegisterScannableStruct(types.JSONStr{})
+	RegisterScannableStruct(types.NullJSONStr{})
+	RegisterScannableStruct(types.CompactJSONStr{})
+	RegisterScannableStruct(types.NullCompactJSONStr{})
 }
 
 // RegisterScannableStruct registers a struct (through an instance or pointer)

--- a/types/cjsonstr.go
+++ b/types/cjsonstr.go
@@ -1,0 +1,111 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"database/sql/driver"
+	"bytes"
+)
+// CompactJSONStr is `json.RawMessage` (`[]byte`) type, adding `Value()` and `Scan()` methods for db access
+// and `MarshalJSON`, `UnmarshalJSON` for json serializing.
+// Also `Unmarshal` method can be used to unmarshals json to an interface type.
+// This type make use of DB binary or string fields like a JSON container.
+// DB field type can be text types like CHAR, STRING, CHARACTER VARYING, TEXT or binary types like JSONB, BYTEA, BLOB...
+//
+// JSON data is hold as "compacted" mode in database.
+//
+// For performance binary db field use is advised.
+type CompactJSONStr json.RawMessage
+
+// MarshalJSON returns JSON encoding
+func (js CompactJSONStr) MarshalJSON() ([]byte, error) {
+	if len(js) == 0 {
+		return CompactJSONStr("{}"), nil
+	}
+	return js, nil
+}
+
+// UnmarshalJSON sets copy of data to instance
+func (js *CompactJSONStr) UnmarshalJSON(data []byte) error {
+	if js == nil {
+		return fmt.Errorf("CompactJSONStr: UnmarshalJSON on nil pointer")
+	}
+	*js = append((*js)[0:0], data...)
+	return nil
+}
+
+// Value returns value. Validates JSON.
+// If value is invalid json, it returns an error.
+func (c CompactJSONStr) Value() (driver.Value, error) {
+	var m json.RawMessage
+	var err = c.Unmarshal(&m)
+	if err != nil {
+		return []byte{}, err
+	}
+	var buf bytes.Buffer
+	err = json.Compact(&buf, []byte(c))
+	return buf.Bytes(), err
+}
+
+// Scan stores the value as CompactJSONStr. Value can be string, []byte or or nil.
+func (js *CompactJSONStr) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		source = []byte(t)
+	case []byte:
+		if len(t) == 0 {
+			source = CompactJSONStr("{}")
+		} else {
+			source = t
+		}
+	case nil:
+		*js = CompactJSONStr("{}")
+	default:
+		return fmt.Errorf("Incompatible type for CompactJSONStr")
+	}
+	*js = CompactJSONStr(append((*js)[0:0], source...))
+	return nil
+}
+
+// Unmarshal unmarshal's using json.Unmarshal.
+func (js *CompactJSONStr) Unmarshal(v interface{}) error {
+	if len(*js) == 0 {
+		*js = CompactJSONStr("{}")
+	}
+	return json.Unmarshal([]byte(*js), v)
+}
+
+// String does pretty printing
+func (js CompactJSONStr) String() string {
+	return string(js)
+}
+
+// NullCompactJSONStr can be an CompactJSONStr or a null value. Can be used like `JSONStr`
+type NullCompactJSONStr struct {
+	CompactJSONStr
+	Valid bool // Valid is true if CompactJSONStr is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (n *NullCompactJSONStr) Scan(value interface{}) error {
+	if value == nil {
+		n.CompactJSONStr, n.Valid = CompactJSONStr("{}"), false
+		return nil
+	}
+	n.Valid = true
+	return n.CompactJSONStr.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (n NullCompactJSONStr) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.CompactJSONStr.Value()
+}
+
+// NullCompactJSONStrFrom creates a valid NullCompactJSONStr
+func NullCompactJSONStrFrom(dst []byte) NullCompactJSONStr {
+	return NullCompactJSONStr{CompactJSONStr: dst, Valid: true}
+}

--- a/types/cjsonstr.go
+++ b/types/cjsonstr.go
@@ -6,9 +6,13 @@ import (
 	"database/sql/driver"
 	"bytes"
 )
+// CompactJSONStr is same as JSONStr except, whitespaces are remove from JSON formatted data while saving to database.
+// It is useless if data is hold in database specific json typed field(like PostgreSQL's JSONB field).
+// NullCompactJSONStr is nullable version of CompactJSONStr.
+//
 // CompactJSONStr is `json.RawMessage` (`[]byte`) type, adding `Value()` and `Scan()` methods for db access
 // and `MarshalJSON`, `UnmarshalJSON` for json serializing.
-// Also `Unmarshal` method can be used to unmarshals json to an interface type.
+//
 // This type make use of DB binary or string fields like a JSON container.
 // DB field type can be text types like CHAR, STRING, CHARACTER VARYING, TEXT or binary types like JSONB, BYTEA, BLOB...
 //

--- a/types/cjsonstr_test.go
+++ b/types/cjsonstr_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
+)
+
+type CompactJsonStrTest struct {
+	A string `json:"a" db:"a"`
+	B int64 `json:"b" db:"b"`
+}
+
+func TestCompactJSONStr(t *testing.T) {
+	Convey("Given CompactJSONStr", t, func() {
+		Convey("valid value", func() {
+			x := CompactJSONStr(`{"a": "test", "b": 2}`)
+			v, err := x.Value()
+			So(err, ShouldEqual, nil)
+			So(v, ShouldNotEqual, nil)
+			So(fmt.Sprintf("%s", v.([]byte)), ShouldEqual, `{"a":"test","b":2}`)
+			err = (&x).Scan(v)
+			So(err, ShouldEqual, nil)
+			m := CompactJsonStrTest{}
+			err = x.Unmarshal(&m)
+			So(err, ShouldEqual, nil)
+			So(m.A, ShouldEqual, "test")
+			So(m.B, ShouldEqual, 2)
+		})
+
+		Convey("nil value", func() {
+			x := NullCompactJSONStr{}
+			err := x.Scan(`{"a": "test", "b": 2}`)
+			So(err, ShouldEqual, nil)
+			v, err := x.Value()
+			So(err, ShouldEqual, nil)
+			So(v, ShouldNotEqual, nil)
+			So(fmt.Sprintf("%s", v.([]byte)), ShouldEqual, `{"a":"test","b":2}`)
+			err = (&x).Scan(v)
+			So(err, ShouldEqual, nil)
+			m := CompactJsonStrTest{}
+			err = x.Unmarshal(&m)
+			So(err, ShouldEqual, nil)
+			So(m.A, ShouldEqual, "test")
+			So(m.B, ShouldEqual, 2)
+
+			x = NullCompactJSONStr{}
+			err = x.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(x.Valid, ShouldNotEqual, true)
+		})
+	})
+}

--- a/types/jsonstr.go
+++ b/types/jsonstr.go
@@ -1,0 +1,159 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// JSONStr is `json.RawMessage` (`[]byte`) type, adding `Value()` and `Scan()` methods for db access
+// and `MarshalJSON`, `UnmarshalJSON` for json serializing.
+// Also `Unmarshal` method can be used to unmarshals json to an interface type.
+// This type make use of DB binary or string fields like a JSON container.
+// DB field type can be text types like CHAR, STRING, CHARACTER VARYING, TEXT or binary types like JSONB, BYTEA, BLOB...
+//
+// For performance binary db field use is advised.
+//
+// Example Usage:
+//
+// For table:
+//  	CREATE TABLE books (
+//  	meta      TEXT
+//  	metab	  BYTEA -- or BLOB or JSONB
+//  	);
+// Example:
+//  	type Book struct {
+//  		Id        int                 `db:"id,key,auto"`
+//  		Meta      types.NullJSONStr   `db:"meta"`
+//  		Metab     types.NullJSONStr   `db:"metab"`
+//  	}
+//  	func (b *Book) TableName() string {
+//  		return "books"
+//  	}
+
+//  	bookTheHobbit := Book{
+//  		Meta:      types.NullJSONStrFrom([]byte(`{"isdn":"123"}`)),
+//  		Metab:     types.NullJSONStrFrom([]byte(`{"isdn":"123aaaaaaaa"}`)),
+//  	}
+//  	if err = db.Insert(&bookTheHobbit).Do(); err != nil {
+//  		panic(fmt.Sprintf("can not insert book err: %v", err))
+//  	}
+//
+//  	b := Book{}
+//  	err = db.Select(&b).
+//  		Where("id = ?", bookTheHobbit.Id).Do()
+//  	if err == sql.ErrNoRows {
+//  		fmt.Println("Book not found !")
+//  	} else if err != nil {
+//  		panic(fmt.Sprintf("can not get book err: %v", err))
+//  	}
+//  	fmt.Printf("------Meta: %v, Metabin: %v\n", b.Meta, b.Metab)
+//  	meta := Meta{}
+//  	err = b.Metab.Unmarshal(&meta)
+//  	fmt.Printf("------Meta: %v, err: %v\n", meta, err)
+//
+//  	metaVal := ""
+//  	metabVal := []byte("")
+//  	err = db.SelectFrom("books"). //
+//  		Columns("meta", "metab").
+//  		Scanx(&metaVal, &metabVal)
+//  	if err == sql.ErrNoRows {
+//  		fmt.Println("Book not found !")
+//  	} else if err != nil {
+//  		panic(fmt.Sprintf("can not get book err: %v", err))
+//  	}
+//  	fmt.Printf("Meta: %v, Metabin: %v\n", metaVal, metabVal)
+//
+
+type JSONStr json.RawMessage
+
+// MarshalJSON returns JSON encoding
+func (js JSONStr) MarshalJSON() ([]byte, error) {
+	if len(js) == 0 {
+		return JSONStr("{}"), nil
+	}
+	return js, nil
+}
+
+// UnmarshalJSON sets copy of data to instance
+func (js *JSONStr) UnmarshalJSON(data []byte) error {
+	if js == nil {
+		return fmt.Errorf("JSONStr: UnmarshalJSON on nil pointer")
+	}
+	*js = append((*js)[0:0], data...)
+	return nil
+}
+
+// Value returns value. Validates JSON.
+// If value is invalid json, it returns an error.
+func (js JSONStr) Value() (driver.Value, error) {
+	var m json.RawMessage
+	var err = js.Unmarshal(&m)
+	if err != nil {
+		return []byte{}, err
+	}
+	return []byte(js), nil
+}
+
+// Scan stores the value as JSONStr. Value can be string, []byte or or nil.
+func (js *JSONStr) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		source = []byte(t)
+	case []byte:
+		if len(t) == 0 {
+			source = JSONStr("{}")
+		} else {
+			source = t
+		}
+	case nil:
+		*js = JSONStr("{}")
+	default:
+		return fmt.Errorf("Incompatible type for JSONStr")
+	}
+	*js = JSONStr(append((*js)[0:0], source...))
+	return nil
+}
+
+// Unmarshal unmarshal's using json.Unmarshal.
+func (js *JSONStr) Unmarshal(v interface{}) error {
+	if len(*js) == 0 {
+		*js = JSONStr("{}")
+	}
+	return json.Unmarshal([]byte(*js), v)
+}
+
+// String does pretty printing
+func (js JSONStr) String() string {
+	return string(js)
+}
+
+// NullJSONStr can be an JSONStr or a null value. Can be used like `sql.NullSting`
+type NullJSONStr struct {
+	JSONStr
+	Valid bool // Valid is true if JSONStr is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (n *NullJSONStr) Scan(value interface{}) error {
+	if value == nil {
+		n.JSONStr, n.Valid = JSONStr("{}"), false
+		return nil
+	}
+	n.Valid = true
+	return n.JSONStr.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (n NullJSONStr) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.JSONStr.Value()
+}
+
+// NullJSONStrFrom creates a valid NullJSONStr
+func NullJSONStrFrom(dst []byte) NullJSONStr {
+	return NullJSONStr{JSONStr: dst, Valid: true}
+}

--- a/types/jsonstr_test.go
+++ b/types/jsonstr_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
+)
+
+type JsonStrTest struct {
+	A string `json:"a" db:"a"`
+	B int64 `json:"b" db:"b"`
+}
+
+func TestJSONStr(t *testing.T) {
+	Convey("Given JSONStr", t, func() {
+		Convey("valid value", func() {
+			x := JSONStr(`{"a": "test", "b": 2}`)
+			v, err := x.Value()
+			So(err, ShouldEqual, nil)
+			So(v, ShouldNotEqual, nil)
+			So(fmt.Sprintf("%s", v.([]byte)), ShouldEqual, `{"a": "test", "b": 2}`)
+			err = (&x).Scan(v)
+			So(err, ShouldEqual, nil)
+			m := JsonStrTest{}
+			err = x.Unmarshal(&m)
+			So(err, ShouldEqual, nil)
+			So(m.A, ShouldEqual, "test")
+			So(m.B, ShouldEqual, 2)
+		})
+
+		Convey("nil value", func() {
+			x := NullJSONStr{}
+			err := x.Scan(`{"a": "test", "b": 2}`)
+			So(err, ShouldEqual, nil)
+			v, err := x.Value()
+			So(err, ShouldEqual, nil)
+			So(v, ShouldNotEqual, nil)
+			So(fmt.Sprintf("%s", v.([]byte)), ShouldEqual, `{"a": "test", "b": 2}`)
+			err = (&x).Scan(v)
+			So(err, ShouldEqual, nil)
+			m := JsonStrTest{}
+			err = x.Unmarshal(&m)
+			So(err, ShouldEqual, nil)
+			So(m.A, ShouldEqual, "test")
+			So(m.B, ShouldEqual, 2)
+
+			x = NullJSONStr{}
+			err = x.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(x.Valid, ShouldNotEqual, true)
+		})
+	})
+}


### PR DESCRIPTION
`JSONStr` makes easy to handle JSON data at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields(like BLOB, BYTEA, JSONB). `NullJSONStr` is Nullable version of `JSONStr`.

`CompactJSONStr` is same as `JSONStr` except, whitespaces are remove from JSON formatted data while saving to database. It is useless if data is hold in database specific json typed field(like PostgreSQL's JSONB field).  `NullCompactJSONStr` is nullable version of `CompactJSONStr`.

Tested on PosgreSQL 9.6, CockroachDB 2 and SqlLite, but should run on others, as these new types depend on database's TEXT or BLOB fields.