### PR TITLE
`NullTime.Scan()` patched  for nil values scanning

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -1,6 +1,5 @@
 package types
 
-
 import (
 	"database/sql/driver"
 	"fmt"
@@ -16,7 +15,7 @@ type NullTime struct {
 // Scan implements the time scanner interface.
 func (nt *NullTime) Scan(value interface{}) error {
 	nt.Time, nt.Valid = value.(time.Time)
-	if !nt.Valid || value != nil {
+	if !nt.Valid && value != nil {
 		return fmt.Errorf("invalid type %T for NullTime: %v", value, value)
 	}
 	return nil

--- a/types/time.go
+++ b/types/time.go
@@ -16,7 +16,7 @@ type NullTime struct {
 // Scan implements the time scanner interface.
 func (nt *NullTime) Scan(value interface{}) error {
 	nt.Time, nt.Valid = value.(time.Time)
-	if !nt.Valid {
+	if !nt.Valid || value != nil {
 		return fmt.Errorf("invalid type %T for NullTime: %v", value, value)
 	}
 	return nil

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -23,7 +23,7 @@ func TestNullTime(t *testing.T) {
 		Convey("nil value", func() {
 			var nullTime NullTime
 			err := nullTime.Scan(nil)
-			So(err, ShouldNotEqual, nil)
+			So(err, ShouldEqual, nil)
 			So(nullTime.Valid, ShouldEqual, false)
 			So(nullTime.Time.Second(), ShouldEqual, 0)
 		})


### PR DESCRIPTION
`NullTime.Scan()` incorrectly raises error if value is nil, patched.