### PR TITLE
BlackListing or WhiteListing columns for struct based inserts and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ godb is a project that is still young and evolving. The API is almost stable, bu
 - `OUTPUT` support for SQL Server.
 - Define your own logger (should have `Println(...)` method)
 - Define model struct name to db table naming with `db.SetDefaultTableNamer(yourFn)`. Supported types are: Plural,Snake,SnakePlural. You can also define `TableName() string` method to for your struct and return whatever table name will be.
+- BlackListing or WhiteListing columns for struct based inserts and updates.
 - Could by used with
   - SQLite
   - PostgreSQL

--- a/dbreflect/dbreflect.go
+++ b/dbreflect/dbreflect.go
@@ -373,19 +373,18 @@ func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterCol
 	}
 
 	values := make(map[string]interface{}, ln)
-	flt := func(isAuto bool, colName string) bool {
+	flt := func(colName string) bool {
+		found := false
 		for _, c := range filterColumns {
 			if c == colName {
-				return true
+				found = true
+				break
 			}
 		}
-		if len(filterColumns) > 0 {
-			return false
-		}
-		return !isAuto
+		return found
 	}
 	f := func(fullName string, fieldMapping *fieldMapping, value *reflect.Value) (stop bool, err error) {
-		if flt(fieldMapping.isAuto, fieldMapping.sqlName) {
+		if !fieldMapping.isAuto && flt(fieldMapping.sqlName) {
 			values[fieldMapping.sqlName] = value.Interface()
 		}
 		return false, nil

--- a/dbreflect/dbreflect.go
+++ b/dbreflect/dbreflect.go
@@ -363,7 +363,7 @@ func (sm *StructMapping) GetNonAutoFieldsValues(s interface{}) []interface{} {
 // GetNonAutoFieldsValuesFiltered returns values of fields in filterColumns,
 // if filterColumns is empty than returns values of non auto fields like `GetNonAutoFieldsValues` but
 // as map
-func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterColumns []string) map[string]interface{} {
+func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterColumns []string) ([]string, []interface{}) {
 	// TODO : check type
 	v := reflect.ValueOf(s)
 	v = reflect.Indirect(v)
@@ -372,7 +372,8 @@ func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterCol
 		ln = len(filterColumns)
 	}
 
-	values := make(map[string]interface{}, ln)
+	columns := make([]string, 0, ln)
+	values := make([]interface{}, 0, ln)
 	// Explicitly defined columns in filterColumns will be returned whether it is key column or not
 	flt := func(isAuto bool, colName string) bool {
 		for _, c := range filterColumns {
@@ -387,13 +388,14 @@ func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterCol
 	}
 	f := func(fullName string, fieldMapping *fieldMapping, value *reflect.Value) (stop bool, err error) {
 		if flt(fieldMapping.isAuto, fieldMapping.sqlName) {
-			values[fieldMapping.sqlName] = value.Interface()
+			columns = append(columns, fieldMapping.sqlName)
+			values = append(values, value.Interface())
 		}
 		return false, nil
 	}
 	sm.structMapping.traverseTree("", "", &v, f)
 
-	return values
+	return columns, values
 }
 
 // GetKeyFieldsValues returns values of key fields, in the same order

--- a/dbreflect/dbreflect.go
+++ b/dbreflect/dbreflect.go
@@ -373,18 +373,20 @@ func (sm *StructMapping) GetNonAutoFieldsValuesFiltered(s interface{}, filterCol
 	}
 
 	values := make(map[string]interface{}, ln)
-	flt := func(colName string) bool {
-		found := false
+	// Explicitly defined columns in filterColumns will be returned whether it is key column or not
+	flt := func(isAuto bool, colName string) bool {
 		for _, c := range filterColumns {
 			if c == colName {
-				found = true
-				break
+				return true
 			}
 		}
-		return found
+		if len(filterColumns) > 0 {
+			return false
+		}
+		return !isAuto
 	}
 	f := func(fullName string, fieldMapping *fieldMapping, value *reflect.Value) (stop bool, err error) {
-		if !fieldMapping.isAuto && flt(fieldMapping.sqlName) {
+		if flt(fieldMapping.isAuto, fieldMapping.sqlName) {
 			values[fieldMapping.sqlName] = value.Interface()
 		}
 		return false, nil

--- a/sqlbuffer.go
+++ b/sqlbuffer.go
@@ -389,11 +389,9 @@ func (b *sqlBuffer) writeInsertValues(args [][]interface{}, columnsCount int) *s
 
 	// build (?, ?, ?, ?)
 	valuesPart := buildGroupOfPlaceholders(columnsCount).Bytes()
-	fmt.Printf("\nvaluesPart: %s\n", valuesPart)
 	// insert group of placeholders for each group of values
 	groupCount := len(args)
 	for i, currentGroup := range args {
-		fmt.Printf("\ncurrentGroup: %s\n", currentGroup)
 		if len(currentGroup) != columnsCount {
 			b.err = fmt.Errorf("Values count does not match the columns count")
 			return b

--- a/sqlbuffer.go
+++ b/sqlbuffer.go
@@ -389,10 +389,11 @@ func (b *sqlBuffer) writeInsertValues(args [][]interface{}, columnsCount int) *s
 
 	// build (?, ?, ?, ?)
 	valuesPart := buildGroupOfPlaceholders(columnsCount).Bytes()
-
+	fmt.Printf("\nvaluesPart: %s\n", valuesPart)
 	// insert group of placeholders for each group of values
 	groupCount := len(args)
 	for i, currentGroup := range args {
+		fmt.Printf("\ncurrentGroup: %s\n", currentGroup)
 		if len(currentGroup) != columnsCount {
 			b.err = fmt.Errorf("Values count does not match the columns count")
 			return b

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -135,14 +135,11 @@ func (si *StructInsert) Do() error {
 	// Values
 	values := make([]interface{}, 0, len(columns))
 	len := si.recordDescription.len()
-	wbColsSet := false
 	for i := 0; i < len; i++ {
 		currentRecord := si.recordDescription.index(i)
 		if hasWB {
 			columns, values = si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
-			if !wbColsSet { // order of old columns list and current values list may not be same so, set here:
-				si.insertStatement = si.insertStatement.Columns(si.insertStatement.db.quoteAll(columns)...)
-			}
+			si.insertStatement = si.insertStatement.Columns(si.insertStatement.db.quoteAll(columns)...)
 		} else {
 			values = si.recordDescription.structMapping.GetNonAutoFieldsValues(currentRecord)
 		}

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -67,30 +67,30 @@ func (db *DB) buildInsert(record interface{}) *StructInsert {
 	return si
 }
 
-// WhiteList saves columns to be inserted from struct
+// Whitelist saves columns to be inserted from struct
 // It adds columns to list each time it is called
 // whitelist should not include auto key tagged columns
-func (si *StructInsert) WhiteList(columns ...string) *StructInsert {
+func (si *StructInsert) Whitelist(columns ...string) *StructInsert {
 	si.whiteList = append(si.whiteList, columns...)
 	return si
 }
 
-// WhiteListReset resets whiteList
-func (si *StructInsert) WhiteListReset() *StructInsert {
+// WhitelistReset resets whiteList
+func (si *StructInsert) WhitelistReset() *StructInsert {
 	si.whiteList = nil
 	return si
 }
 
-// BlackList saves columns not to be inserted from struct
+// Blacklist saves columns not to be inserted from struct
 // It adds columns to list each time it is called. If a column defined in whitelist is
 // also given in black list than that column will be blacklisted.
-func (si *StructInsert) BlackList(columns ...string) *StructInsert {
+func (si *StructInsert) Blacklist(columns ...string) *StructInsert {
 	si.blackList = append(si.blackList, columns...)
 	return si
 }
 
-// BlackListReset resets blacklist
-func (si *StructInsert) BlackListReset() *StructInsert {
+// BlacklistReset resets blacklist
+func (si *StructInsert) BlacklistReset() *StructInsert {
 	si.blackList = nil
 	return si
 }

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -153,9 +153,6 @@ func (si *StructInsert) Do() error {
 		si.insertStatement.Values(values...)
 	}
 
-	fmt.Printf("\n cols: %v\n", si.insertStatement.columns)
-	fmt.Printf("\n values: %v\n", si.insertStatement.values)
-
 	// Use a RETURNING (or similar) clause ?
 	returningBuilder, ok := si.insertStatement.db.adapter.(adapters.ReturningBuilder)
 	if ok {
@@ -176,7 +173,6 @@ func (si *StructInsert) Do() error {
 
 	// Case for adapters not implenting ReturningSuffix(), we use the
 	// value given by LastInsertId() (through Do method)
-	fmt.Printf("\n******************************\n")
 	insertedID, err := si.insertStatement.Do()
 	if err != nil {
 		return err

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -131,18 +131,19 @@ func (si *StructInsert) Do() error {
 	si.insertStatement = si.insertStatement.Columns(si.insertStatement.db.quoteAll(columns)...)
 	hasWB := (len(si.whiteList) + len(si.blackList)) > 0
 	// Values
+	values := make([]interface{}, 0, len(columns))
 	len := si.recordDescription.len()
 	for i := 0; i < len; i++ {
 		currentRecord := si.recordDescription.index(i)
 		if hasWB {
-			values := si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
+			valMap := si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
 			for _, c := range columns {
-				si.insertStatement.Values(values[c])
+				values = append(values, valMap[c])
 			}
 		} else {
-			values := si.recordDescription.structMapping.GetNonAutoFieldsValues(currentRecord)
-			si.insertStatement.Values(values...)
+			values = si.recordDescription.structMapping.GetNonAutoFieldsValues(currentRecord)
 		}
+		si.insertStatement.Values(values...)
 	}
 
 	// Use a RETURNING (or similar) clause ?

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -135,10 +135,14 @@ func (si *StructInsert) Do() error {
 	// Values
 	values := make([]interface{}, 0, len(columns))
 	len := si.recordDescription.len()
+	wbColsSet := false
 	for i := 0; i < len; i++ {
 		currentRecord := si.recordDescription.index(i)
 		if hasWB {
-			columns, values = si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
+			if !wbColsSet { // order of old columns list and current values list may not be same so, set here:
+				columns, values = si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
+				wbColsSet = true
+			}
 			si.insertStatement = si.insertStatement.Columns(si.insertStatement.db.quoteAll(columns)...)
 		} else {
 			values = si.recordDescription.structMapping.GetNonAutoFieldsValues(currentRecord)

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -129,14 +129,19 @@ func (si *StructInsert) Do() error {
 	}
 
 	si.insertStatement = si.insertStatement.Columns(si.insertStatement.db.quoteAll(columns)...)
-
+	hasWB := (len(si.whiteList) + len(si.blackList)) > 0
 	// Values
 	len := si.recordDescription.len()
 	for i := 0; i < len; i++ {
 		currentRecord := si.recordDescription.index(i)
-		values := si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
-		for _, c := range columns {
-			si.insertStatement.Values(values[c])
+		if hasWB {
+			values := si.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(currentRecord, columns)
+			for _, c := range columns {
+				si.insertStatement.Values(values[c])
+			}
+		} else {
+			values := si.recordDescription.structMapping.GetNonAutoFieldsValues(currentRecord)
+			si.insertStatement.Values(values...)
 		}
 	}
 

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -69,6 +69,7 @@ func (db *DB) buildInsert(record interface{}) *StructInsert {
 
 // WhiteList saves columns to be inserted from struct
 // It adds columns to list each time it is called
+// whitelist should not include auto key tagged columns
 func (si *StructInsert) WhiteList(columns ...string) *StructInsert {
 	si.whiteList = append(si.whiteList, columns...)
 	return si

--- a/struct_insert_test.go
+++ b/struct_insert_test.go
@@ -150,6 +150,26 @@ func TestBulkInsertDo(t *testing.T) {
 					So(len(retrieveddummies), ShouldEqual, 10)
 				})
 			})
+
+			Convey("Do executes the query using a blacklist", func() {
+				dummies := make([]Dummy, 0, 2)
+				dummy1 := Dummy{
+					AText:           "Dummy1",
+					AnotherText:     "Foo",
+					AnInteger:       12345,
+					ANullableString: sql.NullString{String: "Void", Valid: true},
+				}
+				dummy2 := Dummy{
+					AText:           "Dummy2",
+					AnotherText:     "Foo",
+					AnInteger:       12345,
+					ANullableString: sql.NullString{String: "Void", Valid: true},
+				}
+				dummies = append(dummies, dummy1, dummy2)
+				err := db.BulkInsert(&dummies).Blacklist("a_nullable_string").Do()
+				So(err, ShouldBeNil)
+			})
 		})
 	})
+
 }

--- a/struct_insert_test.go
+++ b/struct_insert_test.go
@@ -166,9 +166,29 @@ func TestBulkInsertDo(t *testing.T) {
 					ANullableString: sql.NullString{String: "Void", Valid: true},
 				}
 				dummies = append(dummies, dummy1, dummy2)
-				err := db.BulkInsert(&dummies).Blacklist("a_nullable_string").Do()
+				err := db.BulkInsert(&dummies).Blacklist("a_nullable_string", "version").Do()
 				So(err, ShouldBeNil)
 			})
+
+			Convey("Do executes the query using a whitelist", func() {
+				dummies := make([]Dummy, 0, 2)
+				dummy1 := Dummy{
+					AText:           "Dummy1",
+					AnotherText:     "Foo",
+					AnInteger:       12345,
+					ANullableString: sql.NullString{String: "Void", Valid: true},
+				}
+				dummy2 := Dummy{
+					AText:           "Dummy2",
+					AnotherText:     "Foo",
+					AnInteger:       12345,
+					ANullableString: sql.NullString{String: "Void", Valid: true},
+				}
+				dummies = append(dummies, dummy1, dummy2)
+				err := db.BulkInsert(&dummies).Whitelist("an_integer", "a_text", "another_text").Do()
+				So(err, ShouldBeNil)
+			})
+
 		})
 	})
 

--- a/struct_insert_test.go
+++ b/struct_insert_test.go
@@ -45,7 +45,7 @@ func TestInsertDo(t *testing.T) {
 			}
 
 			Convey("Do execute the query whitlisted", func() {
-				err := db.Insert(&dummy).WhiteList("a_text", "another_text", "an_integer").Do()
+				err := db.Insert(&dummy).Whitelist("a_text", "another_text", "an_integer").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldBeGreaterThan, 0)
@@ -63,7 +63,7 @@ func TestInsertDo(t *testing.T) {
 			Convey("Do execute the query whitlisted with id", func() {
 				customID := 1453
 				dummy.ID = customID
-				err := db.Insert(&dummy).WhiteList("id", "an_integer", "a_text", "another_text").Do()
+				err := db.Insert(&dummy).Whitelist("id", "an_integer", "a_text", "another_text").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldEqual, customID)
@@ -80,7 +80,7 @@ func TestInsertDo(t *testing.T) {
 			})
 
 			Convey("Do execute the query whitlisted mixed order", func() {
-				err := db.Insert(&dummy).WhiteList("another_text", "an_integer", "a_text").Do()
+				err := db.Insert(&dummy).Whitelist("another_text", "an_integer", "a_text").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldBeGreaterThan, 0)
@@ -96,7 +96,7 @@ func TestInsertDo(t *testing.T) {
 				})
 			})
 			Convey("Do execute the query blacklist", func() {
-				err := db.Insert(&dummy).BlackList("a_nullable_string").Do()
+				err := db.Insert(&dummy).Blacklist("a_nullable_string").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldBeGreaterThan, 0)

--- a/struct_insert_test.go
+++ b/struct_insert_test.go
@@ -1,6 +1,7 @@
 package godb
 
 import (
+	"database/sql"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -31,6 +32,83 @@ func TestInsertDo(t *testing.T) {
 					So(retrieveddummy.AText, ShouldEqual, dummy.AText)
 					So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
 					So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+				})
+			})
+		})
+
+		Convey("Given an object to insert with whitelist/blacklist", func() {
+			dummy := Dummy{
+				AText:           "Foo Bar2",
+				AnotherText:     "Baz2",
+				AnInteger:       12345,
+				ANullableString: sql.NullString{String: "Void", Valid: true},
+			}
+
+			Convey("Do execute the query whitlisted", func() {
+				err := db.Insert(&dummy).WhiteList("a_text", "another_text", "an_integer").Do()
+
+				So(err, ShouldBeNil)
+				So(dummy.ID, ShouldBeGreaterThan, 0)
+
+				Convey("The data are in the database", func() {
+					retrieveddummy := Dummy{}
+					db.Select(&retrieveddummy).Where("id = ?", dummy.ID).Do()
+					So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+					So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+					So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
+					So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
+				})
+			})
+			Convey("Do execute the query whitlisted with id", func() {
+				customID := 1453
+				dummy.ID = customID
+				err := db.Insert(&dummy).WhiteList("id", "an_integer", "a_text", "another_text").Do()
+
+				So(err, ShouldBeNil)
+				So(dummy.ID, ShouldEqual, customID)
+
+				Convey("The data are in the database with custom key", func() {
+					retrieveddummy := Dummy{}
+					db.Select(&retrieveddummy).Where("id = ?", customID).Do()
+					So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+					So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+					So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
+					So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
+				})
+			})
+
+			Convey("Do execute the query whitlisted mixed order", func() {
+				err := db.Insert(&dummy).WhiteList("another_text", "an_integer", "a_text").Do()
+
+				So(err, ShouldBeNil)
+				So(dummy.ID, ShouldBeGreaterThan, 0)
+
+				Convey("The data are in the database", func() {
+					retrieveddummy := Dummy{}
+					db.Select(&retrieveddummy).Where("id = ?", dummy.ID).Do()
+					So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+					So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+					So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
+					So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
+				})
+			})
+			Convey("Do execute the query blacklist", func() {
+				err := db.Insert(&dummy).BlackList("a_nullable_string").Do()
+
+				So(err, ShouldBeNil)
+				So(dummy.ID, ShouldBeGreaterThan, 0)
+
+				Convey("The data are in the database", func() {
+					retrieveddummy := Dummy{}
+					db.Select(&retrieveddummy).Where("id = ?", dummy.ID).Do()
+					So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+					So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+					So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
+					So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
 				})
 			})
 		})

--- a/struct_insert_test.go
+++ b/struct_insert_test.go
@@ -44,8 +44,11 @@ func TestInsertDo(t *testing.T) {
 				ANullableString: sql.NullString{String: "Void", Valid: true},
 			}
 
-			Convey("Do execute the query whitlisted", func() {
-				err := db.Insert(&dummy).Whitelist("a_text", "another_text", "an_integer").Do()
+			Convey("Do execute the query whitelisted after reset", func() {
+				insQ := db.Insert(&dummy)
+				insQ.Whitelist("a_nullable_string")
+				insQ.WhitelistReset()
+				err := insQ.Whitelist("a_text", "another_text", "an_integer").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldBeGreaterThan, 0)
@@ -60,7 +63,7 @@ func TestInsertDo(t *testing.T) {
 					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
 				})
 			})
-			Convey("Do execute the query whitlisted with id", func() {
+			Convey("Do execute the query whitelisted with id", func() {
 				customID := 1453
 				dummy.ID = customID
 				err := db.Insert(&dummy).Whitelist("id", "an_integer", "a_text", "another_text").Do()
@@ -95,8 +98,11 @@ func TestInsertDo(t *testing.T) {
 					So(retrieveddummy.ANullableString.Valid, ShouldEqual, false)
 				})
 			})
-			Convey("Do execute the query blacklist", func() {
-				err := db.Insert(&dummy).Blacklist("a_nullable_string").Do()
+			Convey("Do execute the query blacklist after reset", func() {
+				insQ := db.Insert(&dummy)
+				insQ.Blacklist("a_string")
+				insQ.BlacklistReset()
+				err := insQ.Blacklist("a_nullable_string").Do()
 
 				So(err, ShouldBeNil)
 				So(dummy.ID, ShouldBeGreaterThan, 0)

--- a/struct_update.go
+++ b/struct_update.go
@@ -95,7 +95,7 @@ func (su *StructUpdate) Do() error {
 		columnsToUpdate = columnsToUpdate[:i]
 	}
 
-	columns, values := su.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(su.recordDescription.record, columnsToUpdate)
+	columns, values := su.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(su.recordDescription.record, columnsToUpdate, false)
 	for i, column := range columns {
 		quotedColumn := su.updateStatement.db.adapter.Quote(column)
 		su.updateStatement = su.updateStatement.Set(quotedColumn, values[i])

--- a/struct_update.go
+++ b/struct_update.go
@@ -41,30 +41,30 @@ func (db *DB) Update(record interface{}) *StructUpdate {
 	return su
 }
 
-// WhiteList saves columns to be updated from struct
+// Whitelist saves columns to be updated from struct
 //
 // whitelist should not include auto key tagged columns
-func (su *StructUpdate) WhiteList(columns ...string) *StructUpdate {
+func (su *StructUpdate) Whitelist(columns ...string) *StructUpdate {
 	su.whiteList = append(su.whiteList, columns...)
 	return su
 }
 
-// WhiteListReset resets whiteList
-func (su *StructUpdate) WhiteListReset() *StructUpdate {
+// WhitelistReset resets whiteList
+func (su *StructUpdate) WhitelistReset() *StructUpdate {
 	su.whiteList = nil
 	return su
 }
 
-// BlackList saves columns not to be updated from struct
+// Blacklist saves columns not to be updated from struct
 // It adds columns to list each time it is called. If a column defined in whitelist is
 // also given in black list than that column will be blacklisted.
-func (su *StructUpdate) BlackList(columns ...string) *StructUpdate {
+func (su *StructUpdate) Blacklist(columns ...string) *StructUpdate {
 	su.blackList = append(su.blackList, columns...)
 	return su
 }
 
-// BlackListReset resets blacklist
-func (su *StructUpdate) BlackListReset() *StructUpdate {
+// BlacklistReset resets blacklist
+func (su *StructUpdate) BlacklistReset() *StructUpdate {
 	su.blackList = nil
 	return su
 }

--- a/struct_update.go
+++ b/struct_update.go
@@ -42,6 +42,8 @@ func (db *DB) Update(record interface{}) *StructUpdate {
 }
 
 // WhiteList saves columns to be updated from struct
+//
+// whitelist should not include auto key tagged columns
 func (su *StructUpdate) WhiteList(columns ...string) *StructUpdate {
 	su.whiteList = append(su.whiteList, columns...)
 	return su

--- a/struct_update.go
+++ b/struct_update.go
@@ -95,10 +95,10 @@ func (su *StructUpdate) Do() error {
 		columnsToUpdate = columnsToUpdate[:i]
 	}
 
-	values := su.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(su.recordDescription.record, columnsToUpdate)
-	for _, column := range columnsToUpdate {
+	columns, values := su.recordDescription.structMapping.GetNonAutoFieldsValuesFiltered(su.recordDescription.record, columnsToUpdate)
+	for i, column := range columns {
 		quotedColumn := su.updateStatement.db.adapter.Quote(column)
-		su.updateStatement = su.updateStatement.Set(quotedColumn, values[column])
+		su.updateStatement = su.updateStatement.Set(quotedColumn, values[i])
 	}
 
 	// On which keys

--- a/struct_update_test.go
+++ b/struct_update_test.go
@@ -59,14 +59,17 @@ func TestUpdateDo(t *testing.T) {
 			})
 		})
 
-		Convey("Update update a record whitelisted", func() {
+		Convey("Update update a record whitelisted after reset", func() {
 			dummy := &Dummy{}
 			err := db.Select(dummy).Where("an_integer = ?", 11).Do()
 			So(err, ShouldBeNil)
 			dummy.AText = "New text"
 			dummy.AnotherText = "Replacement text"
 			dummy.AnInteger = 1453
-			err = db.Update(dummy).Whitelist("another_text", "a_text").Do()
+			updQ := db.Update(dummy)
+			updQ.Whitelist("an_integer")
+			updQ.WhitelistReset()
+			err = updQ.Whitelist("another_text", "a_text").Do()
 			So(err, ShouldBeNil)
 
 			Convey("The data are in the database", func() {
@@ -79,14 +82,17 @@ func TestUpdateDo(t *testing.T) {
 			})
 		})
 
-		Convey("Update update a record blacklisted", func() {
+		Convey("Update a record blacklisted after reset", func() {
 			dummy := &Dummy{}
 			err := db.Select(dummy).Where("an_integer = ?", 11).Do()
 			So(err, ShouldBeNil)
 			dummy.AText = "New text"
 			dummy.AnotherText = "Replacement text blacklisted"
 			dummy.AnInteger = 1453
-			err = db.Update(dummy).Blacklist("another_text").Do()
+			updQ := db.Update(dummy)
+			updQ.Blacklist("a_text")
+			updQ.BlacklistReset()
+			err = updQ.Blacklist("another_text").Do()
 			So(err, ShouldBeNil)
 
 			Convey("The data are in the database", func() {
@@ -98,5 +104,6 @@ func TestUpdateDo(t *testing.T) {
 				So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
 			})
 		})
+
 	})
 }

--- a/struct_update_test.go
+++ b/struct_update_test.go
@@ -58,5 +58,45 @@ func TestUpdateDo(t *testing.T) {
 				So(err, ShouldEqual, ErrOpLock)
 			})
 		})
+
+		Convey("Update update a record whitelisted", func() {
+			dummy := &Dummy{}
+			err := db.Select(dummy).Where("an_integer = ?", 11).Do()
+			So(err, ShouldBeNil)
+			dummy.AText = "New text"
+			dummy.AnotherText = "Replacement text"
+			dummy.AnInteger = 1453
+			err = db.Update(dummy).Whitelist("another_text", "a_text").Do()
+			So(err, ShouldBeNil)
+
+			Convey("The data are in the database", func() {
+				retrieveddummy := Dummy{}
+				db.Select(&retrieveddummy).Where("id = ?", dummy.ID).Do()
+				So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+				So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+				So(retrieveddummy.AnotherText, ShouldEqual, dummy.AnotherText)
+				So(retrieveddummy.AnInteger, ShouldNotEqual, dummy.AnInteger)
+			})
+		})
+
+		Convey("Update update a record blacklisted", func() {
+			dummy := &Dummy{}
+			err := db.Select(dummy).Where("an_integer = ?", 11).Do()
+			So(err, ShouldBeNil)
+			dummy.AText = "New text"
+			dummy.AnotherText = "Replacement text blacklisted"
+			dummy.AnInteger = 1453
+			err = db.Update(dummy).Blacklist("another_text").Do()
+			So(err, ShouldBeNil)
+
+			Convey("The data are in the database", func() {
+				retrieveddummy := Dummy{}
+				db.Select(&retrieveddummy).Where("id = ?", dummy.ID).Do()
+				So(retrieveddummy.ID, ShouldEqual, dummy.ID)
+				So(retrieveddummy.AText, ShouldEqual, dummy.AText)
+				So(retrieveddummy.AnotherText, ShouldNotEqual, dummy.AnotherText)
+				So(retrieveddummy.AnInteger, ShouldEqual, dummy.AnInteger)
+			})
+		})
 	})
 }


### PR DESCRIPTION
This PR is to blacklist or whitelist columns during struct based inserts or updates. For example:

```go
type User struct {
	ID             int64            `db:"id,key,auto" json:"id"`
	Username       string           `db:"username" json:"username"`
	LastLoginIP    types.NullString `db:"last_login_ip" json:"last_login_ip" `
	LastLoginTime  types.NullTime   `db:"last_login_time" json:"last_login_time"`
	CreatedAt      time.Time        `db:"created_at,auto" json:"created_at"`
	UpdatedAt      types.NullTime   `db:"updated_at" json:"updated_at"`
}

func insert(db *godb.DB, res *User) error {
     return db.Insert(res).Blacklist("last_login_ip", "last_login_time", "updated_at").Do()
}

func update(db *godb.DB, res *User) error {
     return db.Update(res).Blacklist("last_login_ip", "last_login_time", "created_at").Do()
}

func login(db *godb.DB, res *User) error {
     return db.Update(res).Whitelist("last_login_time", "last_login_ip").Do()
}
```

Also added `BlacklistReset` or `WhitelistReset` for struct based inserts or updates to clear lists.