### PR TITLE
DB error standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ godb is a project that is still young and evolving. The API is almost stable, bu
 - Two adjustable prepared statements caches (with/without transaction).
 - `RETURNING` support for PostgreSQL.
 - `OUTPUT` support for SQL Server.
+- Optional common db errors handling for backend databases.(`db.UseErrorParser()`)
 - Define your own logger (should have `Println(...)` method)
 - Define model struct name to db table naming with `db.SetDefaultTableNamer(yourFn)`. Supported types are: Plural,Snake,SnakePlural. You can also define `TableName() string` method to for your struct and return whatever table name will be.
 - Could by used with

--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -9,6 +9,8 @@ type Adapter interface {
 	// Quote must return an SQL identifier (table name, column name) quoted,
 	// ie : "foo" for SQLite or Postgresql, `foo` for MySQL, [foo] for SQLServer.
 	Quote(string) string
+	// ParseError parses adapter errors and returns a understandable DBError
+	ParseError(error) error
 }
 
 // PlaceholdersReplacer is an interface wrapping the optional

--- a/adapters/mssql/mssql.go
+++ b/adapters/mssql/mssql.go
@@ -102,9 +102,9 @@ func (MSSQL) ParseError(err error) error {
 	if e, ok := err.(ErrorWithNumber); ok {
 		switch e.SQLErrorNumber() {
 		case 2601:
-			return dberror.UniqueConstraint{Message: err.Error(), Field: dberror.ExtractStr(err.Error(), "index '", "'"), Err: err}
+			return dberror.UniqueConstraint{Message: err.Error(), Field: "", Err: err}
 		case 2627:
-			return dberror.UniqueConstraint{Message: err.Error(), Field: dberror.ExtractStr(err.Error(), "constraint '", "'"), Err: err}
+			return dberror.UniqueConstraint{Message: err.Error(), Field: "", Err: err}
 		case 547:
 			return dberror.CheckConstraint{Message: err.Error(), Field: dberror.ExtractStr(err.Error(), "column '", "'"), Err: err}
 		}

--- a/adapters/mysql/mysql.go
+++ b/adapters/mysql/mysql.go
@@ -1,6 +1,9 @@
 package mysql
 
-import _ "github.com/go-sql-driver/mysql"
+import (
+	"github.com/go-sql-driver/mysql"
+	"github.com/samonzeweb/godb/dberror"
+)
 
 type MySQL struct{}
 
@@ -12,4 +15,20 @@ func (MySQL) DriverName() string {
 
 func (MySQL) Quote(identifier string) string {
 	return "`" + identifier + "`"
+}
+
+func (MySQL) ParseError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(*mysql.MySQLError); ok {
+		switch e.Number {
+		case 1062:
+			return dberror.UniqueConstraint{Message: e.Error(), Field: dberror.ExtractStr(e.Message, "key '", "'"), Err: e}
+		case 1452:
+			return dberror.CheckConstraint{Message: e.Error(), Field: dberror.ExtractStr(e.Message, "CONSTRAINT `", "`"), Err: e}
+		}
+	}
+
+	return err
 }

--- a/adapters/sqlite/sqlite.go
+++ b/adapters/sqlite/sqlite.go
@@ -1,6 +1,12 @@
 package sqlite
 
-import _ "github.com/mattn/go-sqlite3"
+import (
+	"strings"
+
+	"github.com/samonzeweb/godb/dberror"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
 
 type SQLite struct{}
 
@@ -12,4 +18,20 @@ func (SQLite) DriverName() string {
 
 func (SQLite) Quote(identifier string) string {
 	return "\"" + identifier + "\""
+}
+
+func (SQLite) ParseError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	e, _ := err.(sqlite3.Error)
+	switch e.ExtendedCode {
+	case sqlite3.ErrConstraintUnique:
+		return dberror.UniqueConstraint{Message: e.Error(), Field: strings.Split(strings.Split(e.Error(), "failed: ")[1], ".")[1], Err: e}
+	case sqlite3.ErrConstraintCheck:
+		return dberror.CheckConstraint{Message: e.Error(), Field: strings.Split(strings.Split(e.Error(), "failed: ")[1], ".")[1], Err: e}
+	default:
+		return err
+	}
 }

--- a/dberror/dberrors.go
+++ b/dberror/dberrors.go
@@ -1,0 +1,41 @@
+package dberror
+
+import "strings"
+
+// UniqueConstraint error is for handling for unique constrait errors
+type UniqueConstraint struct {
+	Message string `json:"message"`
+	Field   string `json:"field"`
+	Err     error  `json:"err"`
+}
+
+func (e UniqueConstraint) Error() string {
+	return e.Message
+}
+
+// CheckConstraint error is for handling for check constrait errors
+type CheckConstraint struct {
+	Message string `json:"message"`
+	Field   string `json:"field"`
+	Err     error  `json:"err"`
+}
+
+func (e CheckConstraint) Error() string {
+	return e.Message
+}
+
+// ForeignKeyConstraint error is for handling for check constrait errors
+type ForeignKeyConstraint struct {
+	Message string `json:"message"`
+	Field   string `json:"field"`
+	Err     error  `json:"err"`
+}
+
+func (e ForeignKeyConstraint) Error() string {
+	return e.Message
+}
+
+// ExtractStr is used to extract error message
+func ExtractStr(s, left, right string) string {
+	return strings.Split(strings.Split(s, left)[1], right)[0]
+}

--- a/godb.go
+++ b/godb.go
@@ -24,6 +24,9 @@ type DB struct {
 	// Prepared Statement cache for DB and Tx
 	stmtCacheDB *StmtCache
 	stmtCacheTx *StmtCache
+	// Optional error parsing by adapters (false by default = legacy mode)
+	// Will probably be the default behavior in new major release.
+	useErrorParser bool
 }
 
 // Placeholder is the placeholder string, use it to build queries.
@@ -80,6 +83,7 @@ func (db *DB) Clone() *DB {
 		defaultTableNamer: db.defaultTableNamer,
 		stmtCacheDB:       newStmtCache(),
 		stmtCacheTx:       newStmtCache(),
+		useErrorParser:    db.useErrorParser,
 	}
 
 	clone.stmtCacheDB.SetSize(db.stmtCacheDB.GetSize())
@@ -185,4 +189,9 @@ func (db *DB) replacePlaceholders(sql string) string {
 // SetDefaultTableNamer sets table naming function
 func (db *DB) SetDefaultTableNamer(tnamer tablenamer.NamerFn) {
 	db.defaultTableNamer = tnamer
+}
+
+// UseErrorParser will allow adapters to parse errors and wrap ones returned by drivers
+func (db *DB) UseErrorParser() {
+	db.useErrorParser = true
 }

--- a/sqlrunner.go
+++ b/sqlrunner.go
@@ -28,7 +28,7 @@ func (db *DB) do(query string, arguments []interface{}) (sql.Result, error) {
 	db.logExecution(consumedTime, query, arguments)
 	if err != nil {
 		db.logExecutionErr(err, query, arguments)
-		return nil, err
+		return nil, db.adapter.ParseError(err)
 	}
 
 	return result, err

--- a/sqlrunner.go
+++ b/sqlrunner.go
@@ -28,7 +28,10 @@ func (db *DB) do(query string, arguments []interface{}) (sql.Result, error) {
 	db.logExecution(consumedTime, query, arguments)
 	if err != nil {
 		db.logExecutionErr(err, query, arguments)
-		return nil, db.adapter.ParseError(err)
+		if db.useErrorParser {
+			return nil, db.adapter.ParseError(err)
+		}
+		return nil, err
 	}
 
 	return result, err


### PR DESCRIPTION
Added a new `ParseError` method to `Adapter` interface which parses adapter's error and provides error standardization like:
```go
import (
	"github.com/samonzeweb/godb/dberror"
)
func () string{ 
    if err := db.Insert(&Book).Do(); err!=nil {
        if e, ok := err.(dberror.UniqueConstraint); ok {
		return fmt.Sprintf("Record with this value already exists, field:%s",e.Field)
	}
	if e, ok := err.(dberror.CheckConstraint); ok {
		return fmt.Sprintf("Record data for column %s is not valid",e.Field)
	}
	if e, ok := err.(dberror.ForeignKeyConstraint); ok {
		return fmt.Sprintf("Referenced value error for column: %s", e.Field)
	}
        return err.Error()
    }
}
```