### PR TITLE
If no columns defined for selection, get all columns

### DIFF
--- a/select_statement.go
+++ b/select_statement.go
@@ -242,6 +242,12 @@ func (ss *SelectStatement) Do(record interface{}) error {
 	if err != nil {
 		return err
 	}
+	// If no columns defined for selection, get all columns (SELECT * FROM)
+	if len(ss.columns) == 0 {
+		ss.areColumnsFromStruct = true
+		columns := ss.db.quoteAll(recordInfo.structMapping.GetAllColumnsNames())
+		ss.columns = append(ss.columns, columns...)
+	}
 
 	// the function which will return the pointers according to the given columns
 	f := func(record interface{}, columns []string) ([]interface{}, error) {

--- a/select_statement.go
+++ b/select_statement.go
@@ -231,6 +231,8 @@ func (ss *SelectStatement) ToSQL() (string, []interface{}, error) {
 
 // Do executes the select statement.
 // The record argument has to be a pointer to a struct or a slice.
+// If no columns is defined for current select statement, all columns are
+// added from record parameter's struct.
 // If the argument is not a slice, a row is expected, and Do returns
 // sql.ErrNoRows is none where found.
 func (ss *SelectStatement) Do(record interface{}) error {

--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -67,7 +67,6 @@ func TestSelectColumnsFromStruct(t *testing.T) {
 				ToSQL()
 			So(err, ShouldNotBeNil)
 		})
-
 	})
 }
 
@@ -431,6 +430,35 @@ func TestSelectDo(t *testing.T) {
 			So(dummiesSlice[1].ANullableString.String, ShouldEqual, "")
 			So(dummiesSlice[2].ANullableString.Valid, ShouldBeFalse)
 		})
+
+		Convey("ColumnsFromStruct with auto added all columns for single record", func() {
+			singleDummy := Dummy{}
+			selectStmt := db.SelectFrom("dummies").
+				Where("an_integer = ?", 13)
+
+			err := selectStmt.Do(&singleDummy)
+			So(err, ShouldBeNil)
+			So(singleDummy.ID, ShouldBeGreaterThan, 0)
+
+			So(err, ShouldBeNil)
+			So(len(selectStmt.columns), ShouldEqual, 6)
+			So(singleDummy.AnInteger, ShouldEqual, 13)
+		})
+
+		Convey("ColumnsFromStruct with auto added all columns for slice", func() {
+			dummiesSlice := make([]*Dummy, 0, 0)
+			selectStmt := db.SelectFrom("dummies").
+				OrderBy("an_integer")
+
+			err := selectStmt.Do(&dummiesSlice)
+			So(err, ShouldBeNil)
+			So(len(selectStmt.columns), ShouldEqual, 6)
+			So(len(dummiesSlice), ShouldEqual, 3)
+			So(dummiesSlice[0].AnInteger, ShouldEqual, 11)
+			So(dummiesSlice[1].AnInteger, ShouldEqual, 12)
+			So(dummiesSlice[2].AnInteger, ShouldEqual, 13)
+		})
+
 	})
 }
 


### PR DESCRIPTION
If no columns defined for selection, get all columns (SELECT * FROM)

```go
booksWithInventories := make([]BooksWithInventories, 0, 0)
db.SelectFrom("books").
    LeftJoin("inventories", "inventories", godb.Q("inventories.book_id = books.id")).
    Do(&booksWithInventories)
```
No need to call `ColumnsFromStruct(&booksWithInventories)`, if we want all columns in destination interface.
