### PR TITLE
Added Int64Slice,StrSlice,Float64Slice and BoolSlice

### DIFF
--- a/types/boolslice.go
+++ b/types/boolslice.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// BoolSlice makes easy to handle JSON encoded bool lists from/to db stored either in TEXT or BLOB.
+//
+// BoolSlice is `[]bool` type, adding `Value()` and `Scan()` methods for db access.
+//
+
+// BoolSlice makes easy to handle JSON encoded bool lists stored at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+type BoolSlice []bool
+
+// Value returns value.
+// If value is invalid value, it returns an error.
+func (ss BoolSlice) Value() (driver.Value, error) {
+	if ss == nil {
+		return nil, nil
+	}
+	return json.Marshal(ss)
+}
+
+// Scan stores the value as BoolSlice. Value can be string, []byte or or nil.
+func (ss *BoolSlice) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = []byte(t)
+		}
+	case []byte:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = t
+		}
+	case nil:
+		*ss = nil
+		return nil
+	default:
+		return fmt.Errorf("Incompatible type for BoolSlice")
+	}
+	err := json.Unmarshal(source, ss)
+	return err
+}

--- a/types/boolslice_test.go
+++ b/types/boolslice_test.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBoolSlice(t *testing.T) {
+	Convey("Given BoolSlice", t, func() {
+		Convey("valid value", func() {
+			v := []bool{true, false, true}
+			nullBoolSlice := BoolSlice(v)
+			So(len(nullBoolSlice), ShouldEqual, len(v))
+			vx, err := nullBoolSlice.Value()
+			So(err, ShouldEqual, nil)
+			So(string(vx.([]byte)), ShouldEqual, `[true,false,true]`)
+
+		})
+
+		Convey("nil value", func() {
+			var nullBoolSlice BoolSlice
+			err := nullBoolSlice.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(len(nullBoolSlice), ShouldEqual, 0)
+		})
+
+		Convey("invalid value", func() {
+			var nullBoolSlice BoolSlice
+			err := nullBoolSlice.Scan("a")
+			So(err, ShouldNotEqual, nil)
+			So(len(nullBoolSlice), ShouldEqual, 0)
+		})
+
+		Convey("parse null", func() {
+			var nullBoolSlice BoolSlice
+			err := nullBoolSlice.Scan([]byte("null"))
+			So(err, ShouldEqual, nil)
+			So(nullBoolSlice, ShouldEqual, nil)
+			So(len(nullBoolSlice), ShouldEqual, 0)
+		})
+
+		Convey("parse from JS", func() {
+			var nullBoolSlice BoolSlice
+			err := nullBoolSlice.Scan([]byte(`[true,false,true]`))
+			So(err, ShouldEqual, nil)
+			So(len(nullBoolSlice), ShouldEqual, 3)
+		})
+	})
+}

--- a/types/boolslice_test.go
+++ b/types/boolslice_test.go
@@ -10,41 +10,40 @@ func TestBoolSlice(t *testing.T) {
 	Convey("Given BoolSlice", t, func() {
 		Convey("valid value", func() {
 			v := []bool{true, false, true}
-			nullBoolSlice := BoolSlice(v)
-			So(len(nullBoolSlice), ShouldEqual, len(v))
-			vx, err := nullBoolSlice.Value()
+			boolSlice := BoolSlice(v)
+			So(len(boolSlice), ShouldEqual, len(v))
+			vx, err := boolSlice.Value()
 			So(err, ShouldEqual, nil)
 			So(string(vx.([]byte)), ShouldEqual, `[true,false,true]`)
-
 		})
 
 		Convey("nil value", func() {
-			var nullBoolSlice BoolSlice
-			err := nullBoolSlice.Scan(nil)
+			var boolSlice BoolSlice
+			err := boolSlice.Scan(nil)
 			So(err, ShouldEqual, nil)
-			So(len(nullBoolSlice), ShouldEqual, 0)
+			So(len(boolSlice), ShouldEqual, 0)
 		})
 
 		Convey("invalid value", func() {
-			var nullBoolSlice BoolSlice
-			err := nullBoolSlice.Scan("a")
+			var boolSlice BoolSlice
+			err := boolSlice.Scan("a")
 			So(err, ShouldNotEqual, nil)
-			So(len(nullBoolSlice), ShouldEqual, 0)
+			So(len(boolSlice), ShouldEqual, 0)
 		})
 
 		Convey("parse null", func() {
-			var nullBoolSlice BoolSlice
-			err := nullBoolSlice.Scan([]byte("null"))
+			var boolSlice BoolSlice
+			err := boolSlice.Scan([]byte("null"))
 			So(err, ShouldEqual, nil)
-			So(nullBoolSlice, ShouldEqual, nil)
-			So(len(nullBoolSlice), ShouldEqual, 0)
+			So(boolSlice, ShouldEqual, nil)
+			So(len(boolSlice), ShouldEqual, 0)
 		})
 
 		Convey("parse from JS", func() {
-			var nullBoolSlice BoolSlice
-			err := nullBoolSlice.Scan([]byte(`[true,false,true]`))
+			var boolSlice BoolSlice
+			err := boolSlice.Scan([]byte(`[true,false,true]`))
 			So(err, ShouldEqual, nil)
-			So(len(nullBoolSlice), ShouldEqual, 3)
+			So(len(boolSlice), ShouldEqual, 3)
 		})
 	})
 }

--- a/types/float64slice.go
+++ b/types/float64slice.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// Float64Slice makes easy to handle JSON encoded float64 lists from/to db stored either in TEXT or BLOB.
+//
+// Float64Slice is `[]float64` type, adding `Value()` and `Scan()` methods for db access.
+//
+
+// Float64Slice makes easy to handle JSON encoded float64 lists stored at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+type Float64Slice []float64
+
+// Value returns value.
+// If value is invalid value, it returns an error.
+func (ss Float64Slice) Value() (driver.Value, error) {
+	if ss == nil {
+		return nil, nil
+	}
+	return json.Marshal(ss)
+}
+
+// Scan stores the value as Float64Slice. Value can be string, []byte or or nil.
+func (ss *Float64Slice) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = []byte(t)
+		}
+	case []byte:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = t
+		}
+	case nil:
+		*ss = nil
+		return nil
+	default:
+		return fmt.Errorf("Incompatible type for Float64Slice")
+	}
+	err := json.Unmarshal(source, ss)
+	return err
+}

--- a/types/float64slice_test.go
+++ b/types/float64slice_test.go
@@ -10,41 +10,40 @@ func TestFloat64Slice(t *testing.T) {
 	Convey("Given Float64Slice", t, func() {
 		Convey("valid value", func() {
 			v := []float64{1.1, 2.2, 3.3}
-			nullFloat64Slice := Float64Slice(v)
-			So(len(nullFloat64Slice), ShouldEqual, len(v))
-			vx, err := nullFloat64Slice.Value()
+			float64Slice := Float64Slice(v)
+			So(len(float64Slice), ShouldEqual, len(v))
+			vx, err := float64Slice.Value()
 			So(err, ShouldEqual, nil)
 			So(string(vx.([]byte)), ShouldEqual, `[1.1,2.2,3.3]`)
-
 		})
 
 		Convey("nil value", func() {
-			var nullFloat64Slice Float64Slice
-			err := nullFloat64Slice.Scan(nil)
+			var float64Slice Float64Slice
+			err := float64Slice.Scan(nil)
 			So(err, ShouldEqual, nil)
-			So(len(nullFloat64Slice), ShouldEqual, 0)
+			So(len(float64Slice), ShouldEqual, 0)
 		})
 
 		Convey("invalid value", func() {
-			var nullFloat64Slice Float64Slice
-			err := nullFloat64Slice.Scan("a")
+			var float64Slice Float64Slice
+			err := float64Slice.Scan("a")
 			So(err, ShouldNotEqual, nil)
-			So(len(nullFloat64Slice), ShouldEqual, 0)
+			So(len(float64Slice), ShouldEqual, 0)
 		})
 
 		Convey("parse null", func() {
-			var nullFloat64Slice Float64Slice
-			err := nullFloat64Slice.Scan([]byte("null"))
+			var float64Slice Float64Slice
+			err := float64Slice.Scan([]byte("null"))
 			So(err, ShouldEqual, nil)
-			So(nullFloat64Slice, ShouldEqual, nil)
-			So(len(nullFloat64Slice), ShouldEqual, 0)
+			So(float64Slice, ShouldEqual, nil)
+			So(len(float64Slice), ShouldEqual, 0)
 		})
 
 		Convey("parse from JS", func() {
-			var nullFloat64Slice Float64Slice
-			err := nullFloat64Slice.Scan([]byte(`[1.1,2.2,3.3]`))
+			var float64Slice Float64Slice
+			err := float64Slice.Scan([]byte(`[1.1,2.2,3.3]`))
 			So(err, ShouldEqual, nil)
-			So(len(nullFloat64Slice), ShouldEqual, 3)
+			So(len(float64Slice), ShouldEqual, 3)
 		})
 	})
 }

--- a/types/float64slice_test.go
+++ b/types/float64slice_test.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFloat64Slice(t *testing.T) {
+	Convey("Given Float64Slice", t, func() {
+		Convey("valid value", func() {
+			v := []float64{1.1, 2.2, 3.3}
+			nullFloat64Slice := Float64Slice(v)
+			So(len(nullFloat64Slice), ShouldEqual, len(v))
+			vx, err := nullFloat64Slice.Value()
+			So(err, ShouldEqual, nil)
+			So(string(vx.([]byte)), ShouldEqual, `[1.1,2.2,3.3]`)
+
+		})
+
+		Convey("nil value", func() {
+			var nullFloat64Slice Float64Slice
+			err := nullFloat64Slice.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(len(nullFloat64Slice), ShouldEqual, 0)
+		})
+
+		Convey("invalid value", func() {
+			var nullFloat64Slice Float64Slice
+			err := nullFloat64Slice.Scan("a")
+			So(err, ShouldNotEqual, nil)
+			So(len(nullFloat64Slice), ShouldEqual, 0)
+		})
+
+		Convey("parse null", func() {
+			var nullFloat64Slice Float64Slice
+			err := nullFloat64Slice.Scan([]byte("null"))
+			So(err, ShouldEqual, nil)
+			So(nullFloat64Slice, ShouldEqual, nil)
+			So(len(nullFloat64Slice), ShouldEqual, 0)
+		})
+
+		Convey("parse from JS", func() {
+			var nullFloat64Slice Float64Slice
+			err := nullFloat64Slice.Scan([]byte(`[1.1,2.2,3.3]`))
+			So(err, ShouldEqual, nil)
+			So(len(nullFloat64Slice), ShouldEqual, 3)
+		})
+	})
+}

--- a/types/int64slice.go
+++ b/types/int64slice.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 )
 
-// Int64Slice makes easy to handle JSON encoded string lists from/to db stored either in TEXT or BLOB.
+// Int64Slice makes easy to handle JSON encoded int64 lists from/to db stored either in TEXT or BLOB.
 //
-// Int64Slice is `[]String` type, adding `Value()` and `Scan()` methods for db access.
+// Int64Slice is `[]int64` type, adding `Value()` and `Scan()` methods for db access.
 //
 
-// Int64Slice makes easy to handle JSON data at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+// Int64Slice makes easy to handle JSON encoded int64 lists stored at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
 type Int64Slice []int64
 
 // Value returns value.

--- a/types/int64slice.go
+++ b/types/int64slice.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// Int64Slice makes easy to handle JSON encoded string lists from/to db stored either in TEXT or BLOB.
+//
+// Int64Slice is `[]String` type, adding `Value()` and `Scan()` methods for db access.
+//
+
+// Int64Slice makes easy to handle JSON data at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+type Int64Slice []int64
+
+// Value returns value.
+// If value is invalid value, it returns an error.
+func (ss Int64Slice) Value() (driver.Value, error) {
+	if ss == nil {
+		return nil, nil
+	}
+	return json.Marshal(ss)
+}
+
+// Scan stores the value as Int64Slice. Value can be string, []byte or or nil.
+func (ss *Int64Slice) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = []byte(t)
+		}
+	case []byte:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = t
+		}
+	case nil:
+		*ss = nil
+		return nil
+	default:
+		return fmt.Errorf("Incompatible type for Int64Slice")
+	}
+	err := json.Unmarshal(source, ss)
+	return err
+}

--- a/types/int64slice_test.go
+++ b/types/int64slice_test.go
@@ -10,41 +10,40 @@ func TestInt64Slice(t *testing.T) {
 	Convey("Given Int64Slice", t, func() {
 		Convey("valid value", func() {
 			v := []int64{1, 2, 3}
-			nullInt64Slice := Int64Slice(v)
-			So(len(nullInt64Slice), ShouldEqual, len(v))
-			vx, err := nullInt64Slice.Value()
+			int64Slice := Int64Slice(v)
+			So(len(int64Slice), ShouldEqual, len(v))
+			vx, err := int64Slice.Value()
 			So(err, ShouldEqual, nil)
 			So(string(vx.([]byte)), ShouldEqual, `[1,2,3]`)
-
 		})
 
 		Convey("nil value", func() {
-			var nullInt64Slice Int64Slice
-			err := nullInt64Slice.Scan(nil)
+			var int64Slice Int64Slice
+			err := int64Slice.Scan(nil)
 			So(err, ShouldEqual, nil)
-			So(len(nullInt64Slice), ShouldEqual, 0)
+			So(len(int64Slice), ShouldEqual, 0)
 		})
 
 		Convey("invalid value", func() {
-			var nullInt64Slice Int64Slice
-			err := nullInt64Slice.Scan("a")
+			var int64Slice Int64Slice
+			err := int64Slice.Scan("a")
 			So(err, ShouldNotEqual, nil)
-			So(len(nullInt64Slice), ShouldEqual, 0)
+			So(len(int64Slice), ShouldEqual, 0)
 		})
 
 		Convey("parse null", func() {
-			var nullInt64Slice Int64Slice
-			err := nullInt64Slice.Scan([]byte("null"))
+			var int64Slice Int64Slice
+			err := int64Slice.Scan([]byte("null"))
 			So(err, ShouldEqual, nil)
-			So(nullInt64Slice, ShouldEqual, nil)
-			So(len(nullInt64Slice), ShouldEqual, 0)
+			So(int64Slice, ShouldEqual, nil)
+			So(len(int64Slice), ShouldEqual, 0)
 		})
 
 		Convey("parse from JS", func() {
-			var nullInt64Slice Int64Slice
-			err := nullInt64Slice.Scan([]byte(`[1,2,3]`))
+			var int64Slice Int64Slice
+			err := int64Slice.Scan([]byte(`[1,2,3]`))
 			So(err, ShouldEqual, nil)
-			So(len(nullInt64Slice), ShouldEqual, 3)
+			So(len(int64Slice), ShouldEqual, 3)
 		})
 	})
 }

--- a/types/int64slice_test.go
+++ b/types/int64slice_test.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestInt64Slice(t *testing.T) {
+	Convey("Given Int64Slice", t, func() {
+		Convey("valid value", func() {
+			v := []int64{1, 2, 3}
+			nullInt64Slice := Int64Slice(v)
+			So(len(nullInt64Slice), ShouldEqual, len(v))
+			vx, err := nullInt64Slice.Value()
+			So(err, ShouldEqual, nil)
+			So(string(vx.([]byte)), ShouldEqual, `[1,2,3]`)
+
+		})
+
+		Convey("nil value", func() {
+			var nullInt64Slice Int64Slice
+			err := nullInt64Slice.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(len(nullInt64Slice), ShouldEqual, 0)
+		})
+
+		Convey("invalid value", func() {
+			var nullInt64Slice Int64Slice
+			err := nullInt64Slice.Scan("a")
+			So(err, ShouldNotEqual, nil)
+			So(len(nullInt64Slice), ShouldEqual, 0)
+		})
+
+		Convey("parse null", func() {
+			var nullInt64Slice Int64Slice
+			err := nullInt64Slice.Scan([]byte("null"))
+			So(err, ShouldEqual, nil)
+			So(nullInt64Slice, ShouldEqual, nil)
+			So(len(nullInt64Slice), ShouldEqual, 0)
+		})
+
+		Convey("parse from JS", func() {
+			var nullInt64Slice Int64Slice
+			err := nullInt64Slice.Scan([]byte(`[1,2,3]`))
+			So(err, ShouldEqual, nil)
+			So(len(nullInt64Slice), ShouldEqual, 3)
+		})
+	})
+}

--- a/types/strslice.go
+++ b/types/strslice.go
@@ -8,7 +8,7 @@ import (
 
 // StrSlice makes easy to handle JSON encoded string lists from/to db stored either in TEXT or BLOB.
 //
-// StrSlice is `[]String` type, adding `Value()` and `Scan()` methods for db access.
+// StrSlice is `[]string` type, adding `Value()` and `Scan()` methods for db access.
 //
 // Example:
 //
@@ -84,7 +84,7 @@ import (
 // 	fmt.Printf("Null Cities: %v, BigCities: %v\n", cities, bCities)
 // }
 
-// StrSlice makes easy to handle JSON data at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+// StrSlice makes easy to handle JSON encoded string lists stored at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
 type StrSlice []string
 
 // Value returns value.

--- a/types/strslice.go
+++ b/types/strslice.go
@@ -1,0 +1,123 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// StrSlice makes easy to handle JSON encoded string lists from/to db stored either in TEXT or BLOB.
+//
+// StrSlice is `[]String` type, adding `Value()` and `Scan()` methods for db access.
+//
+// Example:
+//
+//
+// package main
+
+// import (
+// 	"encoding/json"
+// 	"fmt"
+
+// 	"github.com/samonzeweb/godb"
+// 	"github.com/samonzeweb/godb/adapters/sqlite"
+// 	"github.com/samonzeweb/godb/types"
+// )
+
+// // Country is db struct
+// type Country struct {
+// 	ID        int            `db:"id,key,auto"`
+// 	Cities    types.StrSlice `db:"cities"`
+// 	BigCities types.StrSlice `db:"big_cities"`
+// }
+
+// // TableName returns db tablename
+// func (b *Country) TableName() string {
+// 	return "countries"
+// }
+
+// func main() {
+// 	db, err := godb.Open(sqlite.Adapter, "./countries.dat")
+// 	if err != nil {
+// 		panic(fmt.Sprintf("db connection err: %v", err))
+// 	}
+// 	if _, err = db.CurrentDB().Exec(`
+// 		CREATE TABLE IF NOT EXISTS countries (
+// 			id 			INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+// 			cities      TEXT NOT NULL,
+// 			big_cities 	TEXT
+// 		);`); err != nil {
+// 		panic(err)
+// 	}
+
+// 	country := Country{
+// 		Cities:    types.StrSlice([]string{"Amsterdam", "Antalya"}),
+// 		BigCities: types.StrSlice([]string{"Istanbul", "Tokyo"}),
+// 	}
+// 	if err = db.Insert(&country).Do(); err != nil {
+// 		panic(err)
+// 	}
+
+// 	// Select
+// 	c := new(Country)
+// 	if err = db.Select(c).Where("id = ?", country.ID).Do(); err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Printf("Cities: %v, BigCities: %v\n", c.Cities, c.BigCities)
+
+// 	res, err := json.MarshalIndent(c, "", "\t")
+// 	fmt.Printf("Json : \n%s\n", res)
+// 	// Scanning into variables
+// 	country = Country{
+// 		Cities:    types.StrSlice([]string{"Amsterdam", "Antalya"}),
+// 		BigCities: nil,
+// 	}
+// 	if err = db.Insert(&country).Do(); err != nil {
+// 		panic(err)
+// 	}
+
+// 	var cities types.StrSlice
+// 	var bCities types.StrSlice
+// 	if err = db.SelectFrom("countries").Columns("cities", "big_cities").Where("id = ?", country.ID).Scanx(&cities, &bCities); err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Printf("Null Cities: %v, BigCities: %v\n", cities, bCities)
+// }
+
+// StrSlice makes easy to handle JSON data at database's text fields(like VARCHAR,CHAR,TEXT) and blob fields
+type StrSlice []string
+
+// Value returns value.
+// If value is invalid value, it returns an error.
+func (ss StrSlice) Value() (driver.Value, error) {
+	if ss == nil {
+		return nil, nil
+	}
+	return json.Marshal(ss)
+}
+
+// Scan stores the value as StrSlice. Value can be string, []byte or or nil.
+func (ss *StrSlice) Scan(src interface{}) error {
+	var source []byte
+	switch t := src.(type) {
+	case string:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = []byte(t)
+		}
+	case []byte:
+		if len(t) == 0 {
+			source = []byte("[]")
+		} else {
+			source = t
+		}
+	case nil:
+		*ss = nil
+		return nil
+	default:
+		return fmt.Errorf("Incompatible type for StrSlice")
+	}
+	err := json.Unmarshal(source, ss)
+	return err
+}

--- a/types/strslice_test.go
+++ b/types/strslice_test.go
@@ -10,41 +10,40 @@ func TestStrSlice(t *testing.T) {
 	Convey("Given StrSlice", t, func() {
 		Convey("valid value", func() {
 			v := []string{"a", "b", "c"}
-			nullStrSlice := StrSlice(v)
-			So(len(nullStrSlice), ShouldEqual, len(v))
-			vx, err := nullStrSlice.Value()
+			strSlice := StrSlice(v)
+			So(len(strSlice), ShouldEqual, len(v))
+			vx, err := strSlice.Value()
 			So(err, ShouldEqual, nil)
 			So(string(vx.([]byte)), ShouldEqual, `["a","b","c"]`)
-
 		})
 
 		Convey("nil value", func() {
-			var nullStrSlice StrSlice
-			err := nullStrSlice.Scan(nil)
+			var strSlice StrSlice
+			err := strSlice.Scan(nil)
 			So(err, ShouldEqual, nil)
-			So(len(nullStrSlice), ShouldEqual, 0)
+			So(len(strSlice), ShouldEqual, 0)
 		})
 
 		Convey("invalid value", func() {
-			var nullStrSlice StrSlice
-			err := nullStrSlice.Scan("1")
+			var strSlice StrSlice
+			err := strSlice.Scan("1")
 			So(err, ShouldNotEqual, nil)
-			So(len(nullStrSlice), ShouldEqual, 0)
+			So(len(strSlice), ShouldEqual, 0)
 		})
 
 		Convey("parse null", func() {
-			var nullStrSlice StrSlice
-			err := nullStrSlice.Scan([]byte("null"))
+			var strSlice StrSlice
+			err := strSlice.Scan([]byte("null"))
 			So(err, ShouldEqual, nil)
-			So(nullStrSlice, ShouldEqual, nil)
-			So(len(nullStrSlice), ShouldEqual, 0)
+			So(strSlice, ShouldEqual, nil)
+			So(len(strSlice), ShouldEqual, 0)
 		})
 
 		Convey("parse from JS", func() {
-			var nullStrSlice StrSlice
-			err := nullStrSlice.Scan([]byte(`["Ankara","Tokyo","Paris"]`))
+			var strSlice StrSlice
+			err := strSlice.Scan([]byte(`["Ankara","Tokyo","Paris"]`))
 			So(err, ShouldEqual, nil)
-			So(len(nullStrSlice), ShouldEqual, 3)
+			So(len(strSlice), ShouldEqual, 3)
 		})
 	})
 }

--- a/types/strslice_test.go
+++ b/types/strslice_test.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStrSlice(t *testing.T) {
+	Convey("Given StrSlice", t, func() {
+		Convey("valid value", func() {
+			v := []string{"a", "b", "c"}
+			nullStrSlice := StrSlice(v)
+			So(len(nullStrSlice), ShouldEqual, len(v))
+			vx, err := nullStrSlice.Value()
+			So(err, ShouldEqual, nil)
+			So(string(vx.([]byte)), ShouldEqual, `["a","b","c"]`)
+
+		})
+
+		Convey("nil value", func() {
+			var nullStrSlice StrSlice
+			err := nullStrSlice.Scan(nil)
+			So(err, ShouldEqual, nil)
+			So(len(nullStrSlice), ShouldEqual, 0)
+		})
+
+		Convey("invalid value", func() {
+			var nullStrSlice StrSlice
+			err := nullStrSlice.Scan("1")
+			So(err, ShouldNotEqual, nil)
+			So(len(nullStrSlice), ShouldEqual, 0)
+		})
+
+		Convey("parse null", func() {
+			var nullStrSlice StrSlice
+			err := nullStrSlice.Scan([]byte("null"))
+			So(err, ShouldEqual, nil)
+			So(nullStrSlice, ShouldEqual, nil)
+			So(len(nullStrSlice), ShouldEqual, 0)
+		})
+
+		Convey("parse from JS", func() {
+			var nullStrSlice StrSlice
+			err := nullStrSlice.Scan([]byte(`["Ankara","Tokyo","Paris"]`))
+			So(err, ShouldEqual, nil)
+			So(len(nullStrSlice), ShouldEqual, 3)
+		})
+	})
+}


### PR DESCRIPTION
Added `Int64Slice,Float64Slice,BoolSlice` and `StrSlice` to `types` package.
- `StrSlice` converts `[]string{"a","b","c"}` to JSON bytes `["a","b","c"]` which can be saved to `BLOB, VARCHAR, TEXT`. And when it reads `["a","b","c"]` from DB, it converts to `[]string{"a","b","c"}`
- `Int64Slice` converts `[]int64{1,2,3}` to JSON bytes `[1,2,3]` which can be saved to `BLOB, VARCHAR, TEXT`. And when it reads `[1,2,3]` from DB, it converts to `[]int64{1,2,3}`
- `Float64Slice` converts `[]float64{1.1,2.2,3.3}` to JSON bytes `[1.1,2.2,3.3]` which can be saved to `BLOB, VARCHAR, TEXT`. And when it reads `[1.1,2.2,3.3]` from DB, it converts to `[]float64{1.1,2.2,3.3}`
- `Bool64Slice` converts `[]bool{true,false,true}` to JSON bytes `[true,false,true]` which can be saved to `BLOB, VARCHAR, TEXT`. And when it reads `[true,false,true]` from DB, it converts to `[]bool{true,false,true}`

Each can be nil also.

Closes #28 