### PR TITLE
added ColumnAlias

### DIFF
--- a/select_statement_test.go
+++ b/select_statement_test.go
@@ -445,6 +445,29 @@ func TestSelectDo(t *testing.T) {
 			So(singleDummy.AnInteger, ShouldEqual, 13)
 		})
 
+		Convey("ColumnAlias with auto added all columns for single record", func() {
+			type DummyAlias struct {
+				ID              int            `db:"id,key,auto"`
+				AText           string         `db:"new_name"`
+				AnotherText     string         `db:"another_text"`
+				AnInteger       int            `db:"an_integer"`
+				ANullableString sql.NullString `db:"a_nullable_string"`
+				Version         int            `db:"version,oplock"`
+			}
+			singleDummy := DummyAlias{}
+			selectStmt := db.SelectFrom("dummies").
+				Where("an_integer = ?", 13)
+			selectStmt.ColumnAlias("a_text", "new_name")
+			selectStmt.OrderBy("new_name")
+			err := selectStmt.Do(&singleDummy)
+			So(err, ShouldBeNil)
+			So(singleDummy.ID, ShouldBeGreaterThan, 0)
+
+			So(err, ShouldBeNil)
+			So(len(selectStmt.columns), ShouldEqual, 6)
+			So(singleDummy.AnInteger, ShouldEqual, 13)
+		})
+
 		Convey("ColumnsFromStruct with auto added all columns for slice", func() {
 			dummiesSlice := make([]*Dummy, 0, 0)
 			selectStmt := db.SelectFrom("dummies").
@@ -458,7 +481,6 @@ func TestSelectDo(t *testing.T) {
 			So(dummiesSlice[1].AnInteger, ShouldEqual, 12)
 			So(dummiesSlice[2].AnInteger, ShouldEqual, 13)
 		})
-
 	})
 }
 


### PR DESCRIPTION
Hi Sam,

Given `dummies table with column `AText` named as `a_text`:
```go
type DummyAlias struct {
	ID              int            `db:"id,key,auto"`
	AText           string         `db:"new_name"`
}
singleDummy := DummyAlias{}
selectStmt := db.SelectFrom("dummies").
	Where("an_integer = ?", 13)
selectStmt.ColumnAlias("a_text", "new_name")
selectStmt.OrderBy("new_name")
```
In the result set column will be named as `new_name`.

OK. Why I need this?

When joinin tables, aliased table columns becomes weird. For following if `ColumnAlias` is not used, tag for `AuthorName` shoul be `db:"a.name"`. And at result rows, column name will be also `a.name`. 

```go
type BookNamed struct {
	Book `db:",rel=b" json:""`   // Embeeding book struct
	AuthorName string `db:"author_name" json:"author_name"` 
}
q := db.SelectFrom("books as b").InnerJoin("authors","a",godb.Q("b.author_id=a.id"))
q.ColumnAlias("a.name", "author_name")
```
The result will be more convenient for SQL producing
```sql
  SELECT b.*, a.name as author_name
    FROM books as b
    JOIN authors as a ON b.author_id = a.id
ORDER BY author_name
```

Regards,
Erkan.