### PR TITLE
Fix a couple of typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ go get github.com/samonzeweb/godb
 
 Install the required driver (see tests). You cas use multiple databases if needed.
 
-Of course you can also use a dependency managment tool like `dep`.
+Of course you can also use a dependency management tool like `dep`.
 
 ## Running Tests
 

--- a/dbreflect/dbreflect.go
+++ b/dbreflect/dbreflect.go
@@ -218,7 +218,7 @@ func (sm *StructMapping) setFieldsCount() {
 	sm.structMapping.traverseTree("", "", nil, f)
 }
 
-// setOpLockField searchs optimistic locking field an update the struct mapping
+// setOpLockField searches optimistic locking field an update the struct mapping
 // with the op lock field data.
 // It returns an error if there is more then one op lock field.
 func (sm *StructMapping) setOpLockField() error {

--- a/dbreflect/dbreflect_test.go
+++ b/dbreflect/dbreflect_test.go
@@ -341,7 +341,7 @@ func TestGetAutoKeyPointer(t *testing.T) {
 		structInstance := BadStructMultipleAutoKey{}
 		structMap, _ := NewStructMapping(reflect.TypeOf(&structInstance))
 
-		Convey("GetAutoKeyPointer returns an error if ther eare multiple auto+key fields", func() {
+		Convey("GetAutoKeyPointer returns an error if there eare multiple auto+key fields", func() {
 			pointer, err := structMap.GetAutoKeyPointer(&structInstance)
 			So(err, ShouldNotBeNil)
 			So(pointer, ShouldBeNil)

--- a/delete_statement.go
+++ b/delete_statement.go
@@ -35,7 +35,7 @@ func (ds *DeleteStatement) WhereQ(condition *Condition) *DeleteStatement {
 	return ds
 }
 
-// Returning adds a RETURNING or OUPUT clause to the statement. Use it with
+// Returning adds a RETURNING or OUTPUT clause to the statement. Use it with
 // PostgreSQL and SQL Server.
 func (ds *DeleteStatement) Returning(columns ...string) *DeleteStatement {
 	ds.returningColumns = append(ds.returningColumns, columns...)

--- a/doc.go
+++ b/doc.go
@@ -40,7 +40,7 @@ Structs tools looks more 'orm-ish' as they're take instances
 of objects or slices to run select, insert, update and delete.
 
 Statements tools stand between raw queries and structs tools. It's easier to
-use than raw queries, but are limited to simplier cases.
+use than raw queries, but are limited to simpler cases.
 
 
 Statements tools
@@ -223,7 +223,7 @@ Databases columns are :
 	* nested_bar
 
 The mapping is managed by the 'dbreflect' subpackage. Normally its direct use
-is not necessary, exept in one case : some structs are scannable and have to be
+is not necessary, except in one case : some structs are scannable and have to be
 considered like fields, and mapped to databases columns. Common case are
 time.Time, or sql.NullString, ... You can register a custom struct with the
 `RegisterScannableStruct` and a struct instance, for example the time.Time is
@@ -243,7 +243,7 @@ Conditions
 
 
 Statements and structs tools manage 'where' and 'group by' sql clauses. These
-conditionnal clauses are build either with raw sql code, or build with the
+conditional clauses are build either with raw sql code, or build with the
 Condition struct like this :
 
 	q := godb.Or(godb.Q("foo is null"), godb.Q("foo > ?", 123))
@@ -406,7 +406,7 @@ sql code, not just select queries.
 To get an interator simply use the `DoWithIterator` method instead of `Do`. The iterator
 usage is similar to the standard `sql.Rows` type. Don't forget to check that there are
 no errors with the `Err` method, and don't forget to call `Close` when the iterator is no
-longer useful, especialy if you don't scan all the resultset.
+longer useful, especially if you don't scan all the resultset.
 
 	iter, err := db.SelectFrom("books").
 		Columns("id", "title", "author", "published").

--- a/insert_statement.go
+++ b/insert_statement.go
@@ -40,7 +40,7 @@ func (is *InsertStatement) Values(values ...interface{}) *InsertStatement {
 	return is
 }
 
-// Returning adds a RETURNING or OUPUT clause to the statement. Use it with
+// Returning adds a RETURNING or OUTPUT clause to the statement. Use it with
 // PostgreSQL and SQL Server.
 func (is *InsertStatement) Returning(columns ...string) *InsertStatement {
 	is.returningColumns = append(is.returningColumns, columns...)

--- a/prepared_statement.go
+++ b/prepared_statement.go
@@ -54,7 +54,7 @@ func (db *DB) getQueryableWithOptions(query string, noTx, noStmtCache bool) (que
 	}
 
 	// If the cache is disabled, or it has not to be used, just return a wrapper
-	// wich look like a prepared statement.
+	// which look like a prepared statement.
 	if !cache.IsEnabled() || noStmtCache {
 		wrapper := queryWrapper{
 			db:       dbOrTx,

--- a/select_statement.go
+++ b/select_statement.go
@@ -105,13 +105,13 @@ func (ss *SelectStatement) Distinct() *SelectStatement {
 	return ss
 }
 
-// InnerJoin adds as INNER JOIN clause, wich will be inserted between FROM and WHERE
+// InnerJoin adds as INNER JOIN clause, which will be inserted between FROM and WHERE
 // clauses.
 func (ss *SelectStatement) InnerJoin(tableName string, as string, on *Condition) *SelectStatement {
 	return ss.addJoin("INNER JOIN", tableName, as, on)
 }
 
-// LeftJoin adds a LEFT JOIN clause, wich will be inserted between FROM and WHERE
+// LeftJoin adds a LEFT JOIN clause, which will be inserted between FROM and WHERE
 // clauses.
 func (ss *SelectStatement) LeftJoin(tableName string, as string, on *Condition) *SelectStatement {
 	return ss.addJoin("LEFT JOIN", tableName, as, on)

--- a/sqlbuffer.go
+++ b/sqlbuffer.go
@@ -133,7 +133,7 @@ func (b *SQLBuffer) Append(other *SQLBuffer) *SQLBuffer {
 	return b
 }
 
-// WriteCondition writes single conditionnal expressions.
+// WriteCondition writes single conditional expressions.
 func (b *SQLBuffer) WriteCondition(condition *Condition) *SQLBuffer {
 	if b.err != nil {
 		return b
@@ -457,7 +457,7 @@ func (b *sqlBuffer) writeNameList(nameList []string) *sqlBuffer {
 	return b
 }
 
-// writeConditions writes conditionnal expressions for WHERE or HAVING clauses
+// writeConditions writes conditional expressions for WHERE or HAVING clauses
 // separated by AND conjunction.
 func (b *sqlBuffer) writeConditions(conditions []*Condition) *sqlBuffer {
 	if b.Err() != nil {

--- a/struct_insert.go
+++ b/struct_insert.go
@@ -179,7 +179,7 @@ func (si *StructInsert) Do() error {
 	}
 
 	// Bulk insert don't update ids with this adater, the insert was done,
-	// without error, but the new ids are unkonwn.
+	// without error, but the new ids are unknown.
 	if si.recordDescription.isSlice {
 		return nil
 	}

--- a/update_statement.go
+++ b/update_statement.go
@@ -69,7 +69,7 @@ func (us *UpdateStatement) WhereQ(condition *Condition) *UpdateStatement {
 	return us
 }
 
-// Returning adds a RETURNING or OUPUT clause to the statement. Use it with
+// Returning adds a RETURNING or OUTPUT clause to the statement. Use it with
 // PostgreSQL and SQL Server.
 func (us *UpdateStatement) Returning(columns ...string) *UpdateStatement {
 	us.returningColumns = append(us.returningColumns, columns...)


### PR DESCRIPTION
Those were found with a Go tool called `misspel` and the following
command: `misspell -w -i transation,constrait .`